### PR TITLE
simulate legit and non-legit messages for particle picking, particle selection and motion correction complete events, ack or nack on the consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ some relevant examples. If it is a library then you might put some
 introductory code here:
 
 ```python
-from cryoem_decision_engine_poc import __version__
+from smartem_decisions import __version__
 
-print(f"Hello cryoem_decision_engine_poc {__version__}")
+print(f"Hello smartem_decisions {__version__}")
 ```
 
 Or if it is a commandline tool then you might put some example commands here:

--- a/simulate-messages.sh
+++ b/simulate-messages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+python src/core/simulate_msg.py --help
+
+python src/core/simulate_msg.py rogue-message
+python src/core/simulate_msg.py rogue-message --no-event-type-missing
+
+python src/core/simulate_msg.py motion-correction-complete
+python src/core/simulate_msg.py motion-correction-complete --no-legit
+
+python src/core/simulate_msg.py particle-picking-complete
+python src/core/simulate_msg.py particle-picking-complete --no-legit
+
+python src/core/simulate_msg.py particle-selection-complete
+python src/core/simulate_msg.py particle-selection-complete --no-legit

--- a/src/core/schemas/mq_event.py
+++ b/src/core/schemas/mq_event.py
@@ -1,10 +1,15 @@
 from enum import Enum
 from pydantic import (
     BaseModel,
+    # ValidationError,
     Field,
     model_validator,
+    field_serializer,
 )
 from uuid import UUID, uuid4
+# import json
+# from typing import no_type_check, Type, Any
+
 
 class MessageQueueEventType(str, Enum):
     """Enum listing various system events that are mapped to messages in RabbitMQ
@@ -20,8 +25,8 @@ class MessageQueueEventType(str, Enum):
     foil_holes_detected = 'foil holes detected'
     foil_holes_decision_start = 'foil holes decision start'
     foil_holes_decision_complete = 'foil holes decision complete'
-    motion_correct_start = 'motion correct start'
-    motion_correct_complete = 'motion correct complete'
+    motion_correction_start = 'motion correction start'
+    motion_correction_complete = 'motion correction complete'
     ctf_start = 'ctf start'
     ctf_complete = 'ctf complete'
     particle_picking_start = 'particle picking start'
@@ -32,7 +37,51 @@ class MessageQueueEventType(str, Enum):
 def non_negative_float(v: float):
     return v >= 0
 
-class MotionCorrectionCompleteBody(BaseModel):
+class GenericEventMessageBody(BaseModel):
+    event_type: MessageQueueEventType
+    @field_serializer('event_type')
+    def serialize_event_type(self, event_type: MessageQueueEventType, _info):
+        return str(event_type.value)
+
+    # In case we ever wanted to handle these internally, otherwise nuke this:
+    # Ref: https://stackoverflow.com/questions/70167626/how-to-prevent-pydantic-from-throwing-an-exception-on-validationerror#71216676
+    # def __init__(__pydantic_self__, **data: Any) -> None:
+    #     try:
+    #         super(GenericEventMessageBody, __pydantic_self__).__init__(**data)
+    #     except ValidationError as pve:
+    #         print(f'This is a warning. __init__ failed to validate:\n {json.dumps(data, indent=4)}\n')
+    #         print(f'This is the original exception:\n{pve.json()}')
+    #
+    # @no_type_check
+    # def __setattr__(self, name, value):
+    #     try:
+    #         return super(GenericEventMessageBody, self).__setattr__(name, value)
+    #     except ValidationError as pve:
+    #         print(f'This is a warning. __setattr__ failed to validate:\n {json.dumps({name: value}, indent=4)}')
+    #         print(f'This is the original exception:\n{pve.json()}')
+    #         return None
+    #
+    # @classmethod
+    # def parse_obj(cls: Type['Model'], obj: Any) -> 'Model':
+    #     try:
+    #         return super(GenericEventMessageBody, cls).parse_obj(obj)
+    #     except ValidationError as pve:
+    #         print(f'This is a warning. parse_obj failed to validate:\n {json.dumps(obj, indent=4)}')
+    #         print(f'This is the original exception:\n{pve.json()}')
+    #         return None
+    #
+    # @classmethod
+    # def parse_raw(cls: Type['Model'], b: None | str | bytes, *, content_type: str = None, encoding: str = 'utf8',
+    #               proto: Any | None = None, allow_pickle: bool = False, ) -> 'Model':
+    #     try:
+    #         return super(GenericEventMessageBody, cls).parse_raw(b=b, content_type=content_type, encoding=encoding,
+    #                                                           proto=proto, allow_pickle=allow_pickle)
+    #     except ValidationError as pve:
+    #         print(f'This is a warning. parse_raw failed to validate:\n {b}')
+    #         print(f'This is the original exception:\n{pve.json()}')
+    #         return None
+
+class MotionCorrectionCompleteBody(GenericEventMessageBody):
     micrograph_id: UUID = Field(..., default_factory=uuid4)
     total_motion: float
     average_motion: float
@@ -47,6 +96,10 @@ class MotionCorrectionCompleteBody(BaseModel):
         if self.ctf_max_resolution_estimate < 0:
             raise ValueError('CTF Max Resolution should be a non-negative float')
         return self
+
+    @field_serializer('micrograph_id')
+    def serialize_micrograph_id(self, micrograph_id: UUID, _info):
+        return str(micrograph_id)
 
 
 class CtfCompleteBody(BaseModel):
@@ -65,6 +118,10 @@ class CtfCompleteBody(BaseModel):
             raise ValueError('CTF Max Resolution should be a non-negative float')
         return self
 
+    @field_serializer('micrograph_id')
+    def serialize_micrograph_id(self, micrograph_id: UUID, _info):
+        return str(micrograph_id)
+
 
 class ParticlePickingCompleteBody(BaseModel):
     micrograph_id: UUID = Field(..., default_factory=uuid4)
@@ -75,7 +132,12 @@ class ParticlePickingCompleteBody(BaseModel):
     def check_model(self):
         if self.number_of_particles_picked < 0:
             raise ValueError('Number of Particles Picked should be a non-negative int')
+        # TODO validate that number of particles picked equals to the size of pick distribution
         return self
+
+    @field_serializer('micrograph_id')
+    def serialize_micrograph_id(self, micrograph_id: UUID, _info):
+        return str(micrograph_id)
 
 
 """For particle selection start see:
@@ -97,27 +159,9 @@ class ParticleSelectionCompleteBody(BaseModel):
     def check_model(self):
         if self.number_of_particles_selected < 0:
             raise ValueError('Number of Particles Selected should be a non-negative int')
+        # TODO validate that number of particles selected equals to the size of selection distribution
         return self
 
-
-
-valid_external_data_1 = {
-    'micrograph_id': uuid4(),
-    'total_motion': 0.123,
-    'average_motion': 0.006,
-    'ctf_max_resolution_estimate': 0.123123,
-}
-invalid_external_data_1 = {
-    'micrograf_id': 'xx',
-    'total_lotion': None,
-    'averag_emotion': -0.006,
-    'ctf_max_revolution_estimate': '0.123123',
-}
-
-try:
-    test_obj_1_valid = MotionCorrectionCompleteBody(**valid_external_data_1)
-    assert test_obj_1_valid.model_dump() == valid_external_data_1
-
-    # test_obj_1_invalid = MotionCorrectionCompleteBody(**invalid_external_data_1)
-except RuntimeError:
-    print(f"Failed ot instantiate MotionCorrectionCTFCompleteBody from: {valid_external_data_1}")
+    @field_serializer('micrograph_id')
+    def serialize_micrograph_id(self, micrograph_id: UUID, _info):
+        return str(micrograph_id)

--- a/src/core/simulate_msg.py
+++ b/src/core/simulate_msg.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
+
 import os
 import pika
 import typer
 import yaml
+import json
 from dotenv import load_dotenv
-load_dotenv()
-from schemas import mq_event
 
+from schemas.mq_event import MessageQueueEventType
+
+load_dotenv()
+from uuid import uuid4
 
 simulate_msg_cli = typer.Typer()
 conf = yaml.safe_load(open(os.path.join(os.path.dirname(__file__), 'config.yaml')))
@@ -21,65 +25,114 @@ connection = pika.BlockingConnection(
         )
     ))
 
-@simulate_msg_cli.command()
-def rouge_message(legit: bool = True):
-    """Simulate an ill-formed message with no valid recipient, i.e. headers
-    fail to specify a valid `event_type` making it impossible to route the
-    message to the correct consumer.
-    """
-    print('Not implemented')
-    pass
-
-
-@simulate_msg_cli.command()
-def external_session_start(legit: bool = True):
-    """Because the session is started manually by the user of EPU software,
-    it's origin is external to the system.
-    """
-    print('Not implemented')
-    pass
-
-@simulate_msg_cli.command()
-def external_grid_scan_start(legit: bool = True):
-    """Simulate a grid scan start event (external to the system)
-    """
-    print('Not implemented')
-    pass
-
-@simulate_msg_cli.command()
-def external_grid_scan_complete(legit: bool = True):
-    """Simulate a grid scan complete event (external to the system)
-    """
-    print('Not implemented')
-    pass
-
-@simulate_msg_cli.command()
-def motion_correct_and_ctf_start(legit: bool = True):
-    """Simulate a motion capture and CTF start message to test workflow response
-    """
-    print('Not implemented')
-    pass
-
-@simulate_msg_cli.command()
-def motion_correct_and_ctf_complete(legit: bool = True):
-    """Simulate a Motion capture and CTF complete message to test workflow response
-    """
+def _send_msg(msg):
     channel = connection.channel()
     channel.queue_declare(queue=conf['rabbitmq']['queue_name'], durable=True)
-    headers = mq_event.MessageQueueEventHeaders(
-        event_type=mq_event.MessageQueueEventType.session_start
-    )
-    message = {}
     channel.basic_publish(
         exchange='',
         routing_key=conf['rabbitmq']['routing_key'],
-        body=str(message),
+        body=json.dumps(msg),
         properties=pika.BasicProperties(
             delivery_mode=pika.DeliveryMode.Persistent
         ))
-    print(f" [x] Sent {message}")
+    print(f" [x] Sent {msg}")
     connection.close()
-    pass
+
+
+@simulate_msg_cli.command()
+def rogue_message(event_type_missing: bool = False):
+    """Simulate an ill-formed message with no valid recipient,
+    either `event_type` parameter taking on an unrecognised value or missing entirely -
+    making it impossible to route the message to the correct consumer.
+    """
+    message = {
+        'event_type': 'foo bar',
+    } if event_type_missing else {
+        'micrograph_id': str(uuid4()),
+        'total_motion': 0.123,
+        'average_motion': 0.006,
+        'ctf_max_resolution_estimate': 0.123123,
+    }
+    _send_msg(message)
+
+@simulate_msg_cli.command()
+def external_session_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def external_grid_scan_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def external_grid_scan_complete(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def motion_correction_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def motion_correction_complete(legit: bool = True):
+    message = {
+        'event_type': str(MessageQueueEventType.motion_correction_complete.value),
+        'micrograph_id': str(uuid4()),
+        'total_motion': 0.123,
+        'average_motion': 0.006,
+        'ctf_max_resolution_estimate': 0.123123,
+    } if legit else {
+        'event_type': str(MessageQueueEventType.motion_correction_complete.value),
+        'micrograf_id': 'xx',
+        'total_lotion': None,
+        'averag_emotion': -0.006,
+        'ctf_max_revolution_estimate': '0.123123',
+    }
+    _send_msg(message)
+
+@simulate_msg_cli.command()
+def particle_picking_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def particle_picking_complete(legit: bool = True):
+    message = {
+        'event_type': str(MessageQueueEventType.particle_picking_complete.value),
+        'micrograph_id': str(uuid4()),
+        'number_of_particles_picked': 10,
+        'pick_distribution': {} # TODO
+    } if legit else {
+        'event_type': str(MessageQueueEventType.particle_picking_complete.value),
+        'micrograf_id': 'xx',
+        'number_of_particles_picked': -10,
+        'pick_distribution': None,
+    }
+    _send_msg(message)
+
+@simulate_msg_cli.command()
+def particle_selection_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def particle_selection_complete(legit: bool = True):
+    message = {
+        'event_type': str(MessageQueueEventType.particle_selection_complete.value),
+        'micrograph_id': str(uuid4()),
+        'number_of_particles_selected': 0,
+        'selection_distribution': {}  # TODO
+    } if legit else {
+        'event_type': str(MessageQueueEventType.particle_selection_complete.value),
+        'micrograf_id': 'xx',
+        'number_of_particles_selected': -10,
+        'selection_distribution': None,
+    }
+    _send_msg(message)
+
+@simulate_msg_cli.command()
+def ctf_start(legit: bool = True):
+    print('Not implemented')
+
+@simulate_msg_cli.command()
+def ctf_complete(legit: bool = True):
+    print('Not implemented')
 
 if __name__ == "__main__":
     simulate_msg_cli()


### PR DESCRIPTION
TODO:
- [x] Simulate motion correction complete valid payload event: `python src/core/simulate_msg.py motion-correction-complete`
- [x] Simulate motion correction complete invalid payload event: `python src/core/simulate_msg.py motion-correction-complete --no-legit`
- [x] Simulate particle picking complete valid payload event: `python src/core/simulate_msg.py particle-picking-complete`
- [x] Simulate particle picking complete invalid payload event: `python src/core/simulate_msg.py particle-picking-complete --no-legit`
- [x] Simulate particle selection complete valid payload event: `python src/core/simulate_msg.py particle-selection-complete`
- [x] Simulate particle selection complete invalid payload event: `python src/core/simulate_msg.py particle-selection-complete --no-legit`
- [x] TODO: simulate a rouge message

TO TEST:

1. `cp .env.example .env && docker compose up -d` to start rabbitmq
2. `python src/core/consumer.py` and leave it listening
3. `./simulate-messages.sh` will simulate a bunch of different messaging scenarios
