### PR TITLE
Add some basic DB structure for Bayesian inference on quality indicator models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smartem-decisions"
-version = "0.0.1"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: Apache Software License",

--- a/src/smartem_decisions/model/database.py
+++ b/src/smartem_decisions/model/database.py
@@ -135,7 +135,7 @@ class QualityPredictionModelWeight(SQLModel, table=True):  # type: ignore
     weight: float
     model: QualityPredictionModel | None = Relationship(back_populates="weights")
     grid: Grid | None = Relationship(back_populates="quality_model_weights")
-    micrograph: Micrograph | None = Relationship(back_poopulates="quality_model_weights")
+    micrograph: Micrograph | None = Relationship(back_populates="quality_model_weights")
 
 
 class QualityPrediction(SQLModel, table=True):  # type: ignore


### PR DESCRIPTION
Static list of "prediction models":

- name
- description

Model parameters (key-value) can be dynamic - a model can update it's own params

Bayesian priors of the models (operate like weights or confidences in the different models given performance throughout the data collection)

We need to have a distinction between a "Prediction Model" in general and a given "Applied Prediction Model" (think better naming) which is a Prediction Model linked to specific experiment data

We need a way of getting prior change history (by means of timestamp column). Also, every weight change should also be linked to a specific movie that caused the change. That way we can analyse what and when caused a weight change.