### PR TITLE
resolve a race condition in EPU data intake fs watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM developer AS build
 COPY . /context
 WORKDIR /context
 COPY pyproject.toml .
-RUN pip install --no-cache-dir . uvicorn
+RUN pip install --no-cache-dir . uvicorn # TODO might need to do `pip install -e .[all]` to get all the deps
 
 # The runtime stage copies the built venv into a slim runtime container
 FROM python:${PYTHON_VERSION}-slim AS runtime
@@ -26,7 +26,7 @@ COPY --from=build /venv/ /venv/
 COPY --from=build /context/ /app/
 ENV PATH=/venv/bin:$PATH
 
-# Copy .env.example as .env
+# Copy .env.example as .env TODO this is now done by setup.py
 COPY .env.example /.env
 
 # change this entrypoint if it is not the same as the repo


### PR DESCRIPTION
The problem we're dealing with - our code works well for parsing a completed directory but has a potential race condition when watching for real-time changes. If files for a grid are written before that grid's `EpuSession.dm` file, we might miss processing them because we haven't created the grid data structure yet.

Here's an approach to solve this:

1. Modify our watcher to maintain a buffer of "orphaned" files - files that appear to belong to a grid that doesn't exist yet
2. When a `EpuSession.dm` file is detected, process it normally AND then check the orphaned files buffer to see if any of them belong to this newly created grid
3. If they do, process them retroactively