### PR TITLE
Fix Windows binary build and optimize CI workflows

### DIFF
--- a/.github/workflows/build_win_fsrecorder.yml
+++ b/.github/workflows/build_win_fsrecorder.yml
@@ -22,6 +22,11 @@ jobs:
     - uses: actions/checkout@v5
       with:
         ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
+        sparse-checkout: |
+          tools/fsrecorder
+          src
+          pyproject.toml
+          README.md
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
@@ -32,7 +37,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pyinstaller
-        pip install -e .[fsrecorder]
+        pip install .[fsrecorder]
 
     - name: Build FSRecorder with PyInstaller
       run: >-

--- a/.github/workflows/build_win_smartem_agent.yml
+++ b/.github/workflows/build_win_smartem_agent.yml
@@ -22,6 +22,10 @@ jobs:
     - uses: actions/checkout@v5
       with:
         ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
+        sparse-checkout: |
+          src
+          pyproject.toml
+          README.md
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
@@ -32,7 +36,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pyinstaller
-        pip install -e .[agent]
+        pip install .[agent]
 
     - name: Build SmartEM Agent tools with PyInstaller
       run: >-
@@ -40,10 +44,6 @@ jobs:
         --name smartem_smartem_agent_tools
         --paths src/smartem_agent
         src/smartem_agent/__main__.py
-
-    - name: Copy README to dist directory
-      run: |
-        copy src/smartem_agent/README.md dist/
 
     - name: Smoke test
       run: |


### PR DESCRIPTION
Issues:

- https://github.com/DiamondLightSource/smartem-decisions/issues/148
- https://github.com/DiamondLightSource/smartem-decisions/issues/72

Changes:

  - [x] Remove missing README copy step from smartem agent build
  - [x] Remove `-e` flag from `pip install` in CI (not needed for binary builds)
  - [x] Add sparse checkout to Windows builds to reduce checkout time and disk usage
  - [x] Optimize fsrecorder build to only fetch required files (`tools/fsrecorder`, `pyproject.toml`)
  - [x] Optimize smartem agent build to only fetch `src` directory

Successful runs:

- https://github.com/DiamondLightSource/smartem-decisions/actions/runs/16935717269
- https://github.com/DiamondLightSource/smartem-decisions/actions/runs/16935790109