### PR TITLE
Configure Dependabot to use admin+devops labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,12 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
     groups:
       actions:
         patterns:
@@ -18,7 +16,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
     groups:
-      dev-dependencies:
+      pip:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "admin"
+      - "devops"
+    groups:
+      docker:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary
- Add explicit `labels:` configuration to all Dependabot ecosystems
- Prevents Dependabot from auto-creating default labels (`dependencies`, `github_actions`, `javascript`)
- Add docker ecosystem for base image updates

## Test plan
- [ ] Verify Dependabot config syntax is valid
- [ ] After merge, trigger Dependabot or wait for next scheduled run
- [ ] Confirm new PRs have `admin` + `devops` labels