### PR TITLE
Add response media types to openapi schema for images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,7 @@ repos:
         ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.14.14
     hooks:
-      - id: ruff
-        args: [--force-exclude]
+      - id: ruff-check
       - id: ruff-format
-        args: [--force-exclude]

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -2366,7 +2366,7 @@ def get_square_latent_rep(prediction_model_name: str, gridsquare_uuid: str, db: 
     return [LatentRepresentationResponse(foilhole_uuid=k, x=v.x, y=v.y, index=v.index) for k, v in rep.items() if v]
 
 
-@app.get("/grids/{grid_uuid}/atlas_image")
+@app.get("/grids/{grid_uuid}/atlas_image", responses={200: {"content": {"image/png": {}}}})
 def get_grid_atlas_image(
     grid_uuid: str,
     x: int | None = None,
@@ -2393,7 +2393,7 @@ def get_grid_atlas_image(
     return Response(im_bytes, media_type="image/png")
 
 
-@app.get("/gridsquares/{gridsquare_uuid}/gridsquare_image")
+@app.get("/gridsquares/{gridsquare_uuid}/gridsquare_image", responses={200: {"content": {"image/png": {}}}})
 def get_gridsquare_image(
     gridsquare_uuid: str,
     db: SqlAlchemySession = DB_DEPENDENCY,


### PR DESCRIPTION
Adds correct content description to a couple of endpoints in the autogenerated openapi schema.

I ran into a problem with the `ruff` pre-commit. It was complaining that it was receiving the `--force-exclude` flag multiple times. I haven't looked into it properly but my assumption is that the flag is baked into the hook in some way. Removing the argument from the pre-commit config fixed for me. I moved to v0.14.14 of the hook while I was at it, not sure if this was lower for a particular reason.