### PR TITLE
feat: SSE event stream for frontend + agent log shipping

### DIFF
--- a/src/smartem_agent/__main__.py
+++ b/src/smartem_agent/__main__.py
@@ -12,6 +12,7 @@ from watchdog.observers import Observer
 from smartem_agent.fs_parser import EpuParser
 from smartem_agent.fs_watcher import DEFAULT_PATTERNS, SmartEMWatcherV2
 from smartem_agent.model.store import InMemoryDataStore
+from smartem_agent.remote_log_handler import RemoteLogHandler
 from smartem_backend.api_client import SmartEMAPIClient as APIClient
 from smartem_common.utils import generate_uuid
 
@@ -198,6 +199,8 @@ def watch_directory(
         logging.error(f"Error: Directory {path} does not exist")
         raise typer.Exit(1)
 
+    remote_log_handler: RemoteLogHandler | None = None
+
     if not dry_run:
         try:
             with APIClient(api_url) as client:
@@ -206,6 +209,16 @@ def watch_directory(
         except Exception as e:
             logging.error(f"Error: API at {api_url} is not reachable: {str(e)}")
             raise typer.Exit(1) from None
+
+        if agent_id and session_id:
+            log_client = APIClient(api_url)
+            remote_log_handler = RemoteLogHandler(
+                api_client=log_client,
+                agent_id=agent_id,
+                session_id=session_id,
+            )
+            logging.getLogger().addHandler(remote_log_handler)
+            logging.info("Remote log handler enabled")
 
     logging.info(
         f"Starting SmartEM Agent to watch directory: {str(path)} "
@@ -232,10 +245,12 @@ def watch_directory(
     observer.schedule(watcher, str(path), recursive=True)
 
     def handle_exit(signum, frame):
-        nonlocal watcher
+        nonlocal watcher, remote_log_handler
         logging.info(watcher.datastore)
         watcher.stop()
         observer.stop()
+        if remote_log_handler:
+            remote_log_handler.close()
         logging.info("Watching stopped")
         observer.join()
         raise typer.Exit()

--- a/src/smartem_agent/remote_log_handler.py
+++ b/src/smartem_agent/remote_log_handler.py
@@ -1,0 +1,64 @@
+import logging
+import threading
+from datetime import UTC, datetime
+
+
+class RemoteLogHandler(logging.Handler):
+    def __init__(
+        self,
+        api_client,
+        agent_id: str,
+        session_id: str,
+        buffer_size: int = 100,
+        flush_interval: float = 5.0,
+    ):
+        super().__init__(level=logging.INFO)
+        self._api_client = api_client
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._buffer_size = buffer_size
+        self._flush_interval = flush_interval
+        self._buffer: list[dict] = []
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._flush_thread = threading.Thread(target=self._flush_loop, daemon=True)
+        self._flush_thread.start()
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            entry = {
+                "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+                "level": record.levelname,
+                "logger_name": record.name,
+                "message": self.format(record) if self.formatter else record.getMessage(),
+            }
+            with self._lock:
+                self._buffer.append(entry)
+                if len(self._buffer) >= self._buffer_size:
+                    self._flush_locked()
+        except Exception:
+            self.handleError(record)
+
+    def _flush_locked(self):
+        if not self._buffer:
+            return
+        batch = self._buffer[:]
+        self._buffer.clear()
+        try:
+            self._api_client.send_logs(self._agent_id, self._session_id, batch)
+        except Exception:
+            pass
+
+    def flush(self):
+        with self._lock:
+            self._flush_locked()
+
+    def _flush_loop(self):
+        while not self._stop_event.wait(self._flush_interval):
+            self.flush()
+
+    def close(self):
+        self._stop_event.set()
+        self._flush_thread.join(timeout=self._flush_interval + 1)
+        self.flush()
+        super().close()

--- a/src/smartem_backend/agent_connection_manager.py
+++ b/src/smartem_backend/agent_connection_manager.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy import and_
 from sqlmodel import Session
 
-from smartem_backend.model.database import AgentConnection, AgentInstruction, AgentSession
+from smartem_backend.model.database import AgentConnection, AgentInstruction, AgentLog, AgentSession
 from smartem_backend.mq_publisher import publish_agent_instruction_expired
 from smartem_backend.utils import get_db_engine
 
@@ -31,19 +31,14 @@ class AgentConnectionManager:
     - Provide connection statistics and monitoring
     """
 
-    def __init__(self, db_engine=None, check_interval: int = 30):
-        """
-        Initialize the connection manager.
-
-        Args:
-            db_engine: Database engine (defaults to global engine)
-            check_interval: How often to run cleanup tasks (seconds)
-        """
+    def __init__(self, db_engine=None, check_interval: int = 30, log_retention_days: int = 7):
         self.db_engine = db_engine or get_db_engine()
         self.check_interval = check_interval
+        self.log_retention_days = log_retention_days
         self.logger = logging.getLogger("AgentConnectionManager")
         self._running = False
         self._task: asyncio.Task | None = None
+        self._log_cleanup_counter = 0
 
     async def start(self):
         """Start the connection manager background tasks."""
@@ -86,12 +81,16 @@ class AgentConnectionManager:
 
     async def _run_cleanup_tasks(self):
         """Run all cleanup and monitoring tasks."""
-        await asyncio.gather(
+        tasks = [
             self._cleanup_stale_connections(),
             self._handle_expired_instructions(),
             self._update_session_activity(),
-            return_exceptions=True,
-        )
+        ]
+        self._log_cleanup_counter += 1
+        if self._log_cleanup_counter >= 120:
+            tasks.append(self._cleanup_old_logs())
+            self._log_cleanup_counter = 0
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _cleanup_stale_connections(self):
         """Clean up connections that haven't received heartbeats recently."""
@@ -207,6 +206,17 @@ class AgentConnectionManager:
 
         except Exception as e:
             self.logger.error(f"Error updating session activity: {e}")
+
+    async def _cleanup_old_logs(self):
+        try:
+            with Session(self.db_engine) as session:
+                cutoff = datetime.now() - timedelta(days=self.log_retention_days)
+                deleted = session.query(AgentLog).filter(AgentLog.created_at < cutoff).delete(synchronize_session=False)
+                if deleted:
+                    session.commit()
+                    self.logger.info(f"Purged {deleted} agent log entries older than {self.log_retention_days} days")
+        except Exception as e:
+            self.logger.error(f"Error cleaning up old agent logs: {e}")
 
     def get_connection_stats(self) -> dict[str, Any]:
         """Get current connection and session statistics."""

--- a/src/smartem_backend/api_client.py
+++ b/src/smartem_backend/api_client.py
@@ -361,6 +361,15 @@ class SmartEMAPIClient:
 
     # Entity-specific methods
 
+    # Agent log shipping
+    def send_logs(self, agent_id: str, session_id: str, logs: list[dict]) -> bool:
+        try:
+            self._request("post", f"agent/{agent_id}/session/{session_id}/logs", {"logs": logs})
+            return True
+        except Exception as e:
+            self._logger.debug(f"Failed to ship logs: {e}")
+            return False
+
     # Status and Health
     def get_status(self) -> dict[str, object]:
         """Get API status information"""

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -2754,9 +2754,9 @@ async def ingest_agent_logs(
     agent_id: str,
     session_id: str,
     request: AgentLogBatchRequest,
-    db: SqlAlchemySession = DB_DEPENDENCY,
+    db: AsyncSession = DB_DEPENDENCY,
 ) -> AgentLogBatchResponse:
-    session = db.query(AgentSession).filter(AgentSession.session_id == session_id).first()
+    session = (await db.execute(select(AgentSession).where(AgentSession.session_id == session_id))).scalars().first()
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     if session.agent_id != agent_id:
@@ -2775,7 +2775,7 @@ async def ingest_agent_logs(
                 message=entry.message,
             )
         )
-    db.commit()
+    await db.commit()
 
     return AgentLogBatchResponse(stored=len(logs_to_store))
 
@@ -2786,7 +2786,7 @@ async def frontend_event_stream(
     acquisition_uuid: str | None = None,
     agent_id: str | None = None,
     event_types: str | None = None,
-    db: SqlAlchemySession = DB_DEPENDENCY,
+    db: AsyncSession = DB_DEPENDENCY,
 ) -> EventSourceResponse:
     global _frontend_sse_connections
     if _frontend_sse_connections >= _frontend_sse_max_connections:
@@ -2818,7 +2818,7 @@ async def frontend_event_stream(
                     pass
 
             if type_enabled(FrontendEventType.AGENT_STATUS):
-                for status_data in query_agent_statuses(db, agent_id):
+                for status_data in await query_agent_statuses(db, agent_id):
                     event_counter += 1
                     yield {
                         "id": str(event_counter),
@@ -2827,7 +2827,7 @@ async def frontend_event_stream(
                     }
 
             if type_enabled(FrontendEventType.ACQUISITION_PROGRESS):
-                for progress in query_acquisition_progress(db, acquisition_uuid):
+                for progress in await query_acquisition_progress(db, acquisition_uuid):
                     event_counter += 1
                     prev_progress[progress["acquisition_uuid"]] = progress
                     yield {
@@ -2856,7 +2856,7 @@ async def frontend_event_stream(
                     }
 
                 if type_enabled(FrontendEventType.AGENT_STATUS):
-                    for status_data in query_agent_statuses(db, agent_id):
+                    for status_data in await query_agent_statuses(db, agent_id):
                         event_counter += 1
                         yield {
                             "id": str(event_counter),
@@ -2865,7 +2865,7 @@ async def frontend_event_stream(
                         }
 
                 if type_enabled(FrontendEventType.ACQUISITION_PROGRESS):
-                    for progress in query_acquisition_progress(db, acquisition_uuid):
+                    for progress in await query_acquisition_progress(db, acquisition_uuid):
                         acq_uuid = progress["acquisition_uuid"]
                         if prev_progress.get(acq_uuid) != progress:
                             prev_progress[acq_uuid] = progress
@@ -2877,7 +2877,7 @@ async def frontend_event_stream(
                             }
 
                 if type_enabled(FrontendEventType.INSTRUCTION_LIFECYCLE):
-                    for instr_data in query_instruction_updates(db, last_poll_time, agent_id):
+                    for instr_data in await query_instruction_updates(db, last_poll_time, agent_id):
                         event_counter += 1
                         yield {
                             "id": str(event_counter),
@@ -2886,7 +2886,7 @@ async def frontend_event_stream(
                         }
 
                 if type_enabled(FrontendEventType.PROCESSING_METRIC):
-                    for metric in query_processing_metrics(db, last_poll_time, acquisition_uuid):
+                    for metric in await query_processing_metrics(db, last_poll_time, acquisition_uuid):
                         event_counter += 1
                         yield {
                             "id": str(event_counter),
@@ -2895,7 +2895,7 @@ async def frontend_event_stream(
                         }
 
                 if type_enabled(FrontendEventType.AGENT_LOG):
-                    logs = query_agent_logs(db, last_log_id, agent_id)
+                    logs = await query_agent_logs(db, last_log_id, agent_id)
                     for log_entry in logs:
                         last_log_id = log_entry["id"]
                         event_counter += 1

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -23,11 +23,19 @@ from sse_starlette.sse import EventSourceResponse
 
 from smartem_backend import mq_publisher as mq_publisher_module
 from smartem_backend.agent_connection_manager import get_connection_manager
+from smartem_backend.frontend_stream import (
+    query_acquisition_progress,
+    query_agent_logs,
+    query_agent_statuses,
+    query_instruction_updates,
+    query_processing_metrics,
+)
 from smartem_backend.model.database import (
     Acquisition,
     AgentConnection,
     AgentInstruction,
     AgentInstructionAcknowledgement,
+    AgentLog,
     AgentSession,
     Atlas,
     AtlasTile,
@@ -49,6 +57,11 @@ from smartem_backend.model.entity_status import (
     GridSquareStatus,
     GridStatus,
     MicrographStatus,
+)
+from smartem_backend.model.frontend_sse_event import (
+    AgentLogBatchRequest,
+    AgentLogBatchResponse,
+    FrontendEventType,
 )
 from smartem_backend.model.http_request import (
     AcquisitionCreateRequest,
@@ -2730,6 +2743,179 @@ async def get_gridsquare_image(
         im.save(buf, format="PNG")
         im_bytes = buf.getvalue()
     return Response(im_bytes, media_type="image/png")
+
+
+_frontend_sse_connections = 0
+_frontend_sse_max_connections = int(os.getenv("FRONTEND_SSE_MAX_CONNECTIONS", "50"))
+
+
+@app.post("/agent/{agent_id}/session/{session_id}/logs")
+async def ingest_agent_logs(
+    agent_id: str,
+    session_id: str,
+    request: AgentLogBatchRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+) -> AgentLogBatchResponse:
+    session = db.query(AgentSession).filter(AgentSession.session_id == session_id).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.agent_id != agent_id:
+        raise HTTPException(status_code=403, detail="Session does not belong to agent")
+
+    max_batch = 500
+    logs_to_store = request.logs[:max_batch]
+    for entry in logs_to_store:
+        db.add(
+            AgentLog(
+                agent_id=agent_id,
+                session_id=session_id,
+                timestamp=entry.timestamp,
+                level=entry.level,
+                logger_name=entry.logger_name,
+                message=entry.message,
+            )
+        )
+    db.commit()
+
+    return AgentLogBatchResponse(stored=len(logs_to_store))
+
+
+@app.get("/frontend/events/stream")
+async def frontend_event_stream(
+    request: Request,
+    acquisition_uuid: str | None = None,
+    agent_id: str | None = None,
+    event_types: str | None = None,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+) -> EventSourceResponse:
+    global _frontend_sse_connections
+    if _frontend_sse_connections >= _frontend_sse_max_connections:
+        raise HTTPException(status_code=503, detail="Too many frontend SSE connections")
+
+    requested_types: set[str] | None = None
+    if event_types:
+        requested_types = {t.strip() for t in event_types.split(",")}
+
+    def type_enabled(event_type: FrontendEventType) -> bool:
+        if requested_types is None:
+            return True
+        return event_type.value in requested_types
+
+    async def event_generator():
+        global _frontend_sse_connections
+        _frontend_sse_connections += 1
+        event_counter = 0
+        last_poll_time = datetime.now()
+        last_log_id = 0
+        prev_progress: dict[str, dict] = {}
+
+        try:
+            last_event_id = request.headers.get("Last-Event-ID")
+            if last_event_id:
+                try:
+                    event_counter = int(last_event_id)
+                except ValueError:
+                    pass
+
+            if type_enabled(FrontendEventType.AGENT_STATUS):
+                for status_data in query_agent_statuses(db, agent_id):
+                    event_counter += 1
+                    yield {
+                        "id": str(event_counter),
+                        "event": FrontendEventType.AGENT_STATUS.value,
+                        "data": json.dumps(status_data),
+                    }
+
+            if type_enabled(FrontendEventType.ACQUISITION_PROGRESS):
+                for progress in query_acquisition_progress(db, acquisition_uuid):
+                    event_counter += 1
+                    prev_progress[progress["acquisition_uuid"]] = progress
+                    yield {
+                        "id": str(event_counter),
+                        "event": FrontendEventType.ACQUISITION_PROGRESS.value,
+                        "data": json.dumps(progress),
+                    }
+
+            heartbeat_counter = 0
+            poll_interval = int(os.getenv("FRONTEND_SSE_POLL_INTERVAL", "5"))
+
+            while True:
+                now = datetime.now()
+
+                if heartbeat_counter % 6 == 0:
+                    event_counter += 1
+                    yield {
+                        "id": str(event_counter),
+                        "event": FrontendEventType.HEARTBEAT.value,
+                        "data": json.dumps(
+                            {
+                                "timestamp": now.isoformat(),
+                                "connection_time_s": (now - last_poll_time).total_seconds(),
+                            }
+                        ),
+                    }
+
+                if type_enabled(FrontendEventType.AGENT_STATUS):
+                    for status_data in query_agent_statuses(db, agent_id):
+                        event_counter += 1
+                        yield {
+                            "id": str(event_counter),
+                            "event": FrontendEventType.AGENT_STATUS.value,
+                            "data": json.dumps(status_data),
+                        }
+
+                if type_enabled(FrontendEventType.ACQUISITION_PROGRESS):
+                    for progress in query_acquisition_progress(db, acquisition_uuid):
+                        acq_uuid = progress["acquisition_uuid"]
+                        if prev_progress.get(acq_uuid) != progress:
+                            prev_progress[acq_uuid] = progress
+                            event_counter += 1
+                            yield {
+                                "id": str(event_counter),
+                                "event": FrontendEventType.ACQUISITION_PROGRESS.value,
+                                "data": json.dumps(progress),
+                            }
+
+                if type_enabled(FrontendEventType.INSTRUCTION_LIFECYCLE):
+                    for instr_data in query_instruction_updates(db, last_poll_time, agent_id):
+                        event_counter += 1
+                        yield {
+                            "id": str(event_counter),
+                            "event": FrontendEventType.INSTRUCTION_LIFECYCLE.value,
+                            "data": json.dumps(instr_data),
+                        }
+
+                if type_enabled(FrontendEventType.PROCESSING_METRIC):
+                    for metric in query_processing_metrics(db, last_poll_time, acquisition_uuid):
+                        event_counter += 1
+                        yield {
+                            "id": str(event_counter),
+                            "event": FrontendEventType.PROCESSING_METRIC.value,
+                            "data": json.dumps(metric),
+                        }
+
+                if type_enabled(FrontendEventType.AGENT_LOG):
+                    logs = query_agent_logs(db, last_log_id, agent_id)
+                    for log_entry in logs:
+                        last_log_id = log_entry["id"]
+                        event_counter += 1
+                        yield {
+                            "id": str(event_counter),
+                            "event": FrontendEventType.AGENT_LOG.value,
+                            "data": json.dumps(log_entry),
+                        }
+
+                last_poll_time = now
+                await asyncio.sleep(poll_interval)
+                heartbeat_counter += 1
+
+        except asyncio.CancelledError:
+            logger.info("Frontend SSE connection closed")
+            raise
+        finally:
+            _frontend_sse_connections -= 1
+
+    return EventSourceResponse(event_generator())
 
 
 if __name__ == "__main__":

--- a/src/smartem_backend/consumer.py
+++ b/src/smartem_backend/consumer.py
@@ -448,6 +448,12 @@ async def handle_motion_correction_complete(event_data: dict[str, Any]) -> None:
             session.add(updated_metric_stats)
             await session.commit()
             await prior_update(quality, event.micrograph_uuid, "motioncorrection", session)
+            micrograph = (
+                await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid))
+            ).scalars().first()
+            if micrograph:
+                micrograph.updated_at = datetime.now()
+                await session.commit()
         await publish_motion_correction_registered(
             event.micrograph_uuid, quality >= 0.5, metric_name="motioncorrection"
         )
@@ -505,6 +511,12 @@ async def handle_ctf_estimation_complete(event_data: dict[str, Any]) -> None:
             session.add(updated_metric_stats)
             await session.commit()
             await prior_update(quality, event.micrograph_uuid, "ctfmaxresolution", session)
+            micrograph = (
+                await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid))
+            ).scalars().first()
+            if micrograph:
+                micrograph.updated_at = datetime.now()
+                await session.commit()
         await publish_ctf_estimation_registered(event.micrograph_uuid, quality >= 0.5, metric_name="ctfmaxresolution")
     except ValidationError as e:
         logger.error(f"Validation error processing ctf event: {e}")

--- a/src/smartem_backend/consumer.py
+++ b/src/smartem_backend/consumer.py
@@ -449,8 +449,10 @@ async def handle_motion_correction_complete(event_data: dict[str, Any]) -> None:
             await session.commit()
             await prior_update(quality, event.micrograph_uuid, "motioncorrection", session)
             micrograph = (
-                await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid))
-            ).scalars().first()
+                (await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid)))
+                .scalars()
+                .first()
+            )
             if micrograph:
                 micrograph.updated_at = datetime.now()
                 await session.commit()
@@ -512,8 +514,10 @@ async def handle_ctf_estimation_complete(event_data: dict[str, Any]) -> None:
             await session.commit()
             await prior_update(quality, event.micrograph_uuid, "ctfmaxresolution", session)
             micrograph = (
-                await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid))
-            ).scalars().first()
+                (await session.execute(select(Micrograph).where(Micrograph.uuid == event.micrograph_uuid)))
+                .scalars()
+                .first()
+            )
             if micrograph:
                 micrograph.updated_at = datetime.now()
                 await session.commit()

--- a/src/smartem_backend/frontend_stream.py
+++ b/src/smartem_backend/frontend_stream.py
@@ -1,0 +1,175 @@
+from datetime import datetime
+
+from sqlalchemy import and_, func, select
+from sqlmodel import Session
+
+from smartem_backend.model.database import (
+    Acquisition,
+    AgentConnection,
+    AgentInstruction,
+    AgentInstructionAcknowledgement,
+    AgentLog,
+    AgentSession,
+    FoilHole,
+    Grid,
+    GridSquare,
+    Micrograph,
+)
+
+
+def query_agent_statuses(db: Session, agent_id: str | None = None) -> list[dict]:
+    query = (
+        select(
+            AgentConnection.agent_id,
+            AgentConnection.status,
+            AgentConnection.last_heartbeat_at,
+            AgentSession.session_id,
+            AgentSession.acquisition_uuid,
+            func.count(AgentConnection.id).label("connection_count"),
+        )
+        .join(AgentSession, AgentConnection.session_id == AgentSession.session_id)
+        .where(AgentConnection.status == "active")
+        .group_by(
+            AgentConnection.agent_id,
+            AgentConnection.status,
+            AgentConnection.last_heartbeat_at,
+            AgentSession.session_id,
+            AgentSession.acquisition_uuid,
+        )
+    )
+    if agent_id:
+        query = query.where(AgentConnection.agent_id == agent_id)
+
+    rows = db.exec(query).all()
+    return [
+        {
+            "agent_id": row.agent_id,
+            "status": "online",
+            "session_id": row.session_id,
+            "acquisition_uuid": row.acquisition_uuid,
+            "last_heartbeat_at": row.last_heartbeat_at.isoformat() if row.last_heartbeat_at else None,
+            "connection_count": row.connection_count,
+        }
+        for row in rows
+    ]
+
+
+def query_acquisition_progress(db: Session, acquisition_uuid: str | None = None) -> list[dict]:
+    acq_query = select(Acquisition.uuid, Acquisition.status)
+    if acquisition_uuid:
+        acq_query = acq_query.where(Acquisition.uuid == acquisition_uuid)
+
+    acquisitions = db.exec(acq_query).all()
+    results = []
+    for acq in acquisitions:
+        grid_count = db.exec(select(func.count()).select_from(Grid).where(Grid.acquisition_uuid == acq.uuid)).one()
+        gridsquare_count = db.exec(
+            select(func.count())
+            .select_from(GridSquare)
+            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+            .where(Grid.acquisition_uuid == acq.uuid)
+        ).one()
+        foilhole_count = db.exec(
+            select(func.count())
+            .select_from(FoilHole)
+            .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
+            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+            .where(Grid.acquisition_uuid == acq.uuid)
+        ).one()
+        micrograph_count = db.exec(
+            select(func.count())
+            .select_from(Micrograph)
+            .join(FoilHole, Micrograph.foilhole_uuid == FoilHole.uuid)
+            .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
+            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+            .where(Grid.acquisition_uuid == acq.uuid)
+        ).one()
+        results.append(
+            {
+                "acquisition_uuid": acq.uuid,
+                "grid_count": grid_count,
+                "gridsquare_count": gridsquare_count,
+                "foilhole_count": foilhole_count,
+                "micrograph_count": micrograph_count,
+                "status": str(acq.status.value) if hasattr(acq.status, "value") else str(acq.status),
+            }
+        )
+    return results
+
+
+def query_instruction_updates(db: Session, since: datetime, agent_id: str | None = None) -> list[dict]:
+    query = select(AgentInstruction).where(
+        (AgentInstruction.created_at > since)
+        | (AgentInstruction.sent_at > since)
+        | (AgentInstruction.acknowledged_at > since)
+    )
+    if agent_id:
+        query = query.where(AgentInstruction.agent_id == agent_id)
+
+    instructions = db.exec(query).all()
+    results = []
+    for instr in instructions:
+        ack = db.exec(
+            select(AgentInstructionAcknowledgement)
+            .where(AgentInstructionAcknowledgement.instruction_id == instr.instruction_id)
+            .order_by(AgentInstructionAcknowledgement.created_at.desc())
+        ).first()
+        results.append(
+            {
+                "instruction_id": instr.instruction_id,
+                "agent_id": instr.agent_id,
+                "session_id": instr.session_id,
+                "instruction_type": instr.instruction_type,
+                "status": instr.status,
+                "created_at": instr.created_at.isoformat(),
+                "sent_at": instr.sent_at.isoformat() if instr.sent_at else None,
+                "acknowledged_at": instr.acknowledged_at.isoformat() if instr.acknowledged_at else None,
+                "ack_status": ack.status if ack else None,
+            }
+        )
+    return results
+
+
+def query_processing_metrics(db: Session, since: datetime, acquisition_uuid: str | None = None) -> list[dict]:
+    query = select(Micrograph).where(and_(Micrograph.updated_at.is_not(None), Micrograph.updated_at > since))
+    if acquisition_uuid:
+        query = (
+            query.join(FoilHole, Micrograph.foilhole_uuid == FoilHole.uuid)
+            .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
+            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+            .where(Grid.acquisition_uuid == acquisition_uuid)
+        )
+
+    micrographs = db.exec(query).all()
+    return [
+        {
+            "micrograph_uuid": m.uuid,
+            "foilhole_uuid": m.foilhole_uuid,
+            "total_motion": m.total_motion,
+            "average_motion": m.average_motion,
+            "ctf_max_resolution_estimate": m.ctf_max_resolution_estimate,
+            "number_of_particles_picked": m.number_of_particles_picked,
+            "number_of_particles_selected": m.number_of_particles_selected,
+        }
+        for m in micrographs
+    ]
+
+
+def query_agent_logs(db: Session, since_id: int, agent_id: str | None = None, limit: int = 200) -> list[dict]:
+    query = select(AgentLog).where(AgentLog.id > since_id).order_by(AgentLog.id).limit(limit)
+    if agent_id:
+        query = query.where(AgentLog.agent_id == agent_id)
+
+    logs = db.exec(query).all()
+    return [
+        {
+            "id": log.id,
+            "agent_id": log.agent_id,
+            "session_id": log.session_id,
+            "timestamp": log.timestamp.isoformat(),
+            "level": log.level,
+            "logger_name": log.logger_name,
+            "message": log.message,
+        }
+        for log in logs
+    ]

--- a/src/smartem_backend/frontend_stream.py
+++ b/src/smartem_backend/frontend_stream.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import and_, func, select
-from sqlmodel import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from smartem_backend.model.database import (
     Acquisition,
@@ -17,7 +17,7 @@ from smartem_backend.model.database import (
 )
 
 
-def query_agent_statuses(db: Session, agent_id: str | None = None) -> list[dict]:
+async def query_agent_statuses(db: AsyncSession, agent_id: str | None = None) -> list[dict]:
     query = (
         select(
             AgentConnection.agent_id,
@@ -40,7 +40,7 @@ def query_agent_statuses(db: Session, agent_id: str | None = None) -> list[dict]
     if agent_id:
         query = query.where(AgentConnection.agent_id == agent_id)
 
-    rows = db.exec(query).all()
+    rows = (await db.execute(query)).all()
     return [
         {
             "agent_id": row.agent_id,
@@ -54,36 +54,44 @@ def query_agent_statuses(db: Session, agent_id: str | None = None) -> list[dict]
     ]
 
 
-def query_acquisition_progress(db: Session, acquisition_uuid: str | None = None) -> list[dict]:
+async def query_acquisition_progress(db: AsyncSession, acquisition_uuid: str | None = None) -> list[dict]:
     acq_query = select(Acquisition.uuid, Acquisition.status)
     if acquisition_uuid:
         acq_query = acq_query.where(Acquisition.uuid == acquisition_uuid)
 
-    acquisitions = db.exec(acq_query).all()
+    acquisitions = (await db.execute(acq_query)).all()
     results = []
     for acq in acquisitions:
-        grid_count = db.exec(select(func.count()).select_from(Grid).where(Grid.acquisition_uuid == acq.uuid)).one()
-        gridsquare_count = db.exec(
-            select(func.count())
-            .select_from(GridSquare)
-            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
-            .where(Grid.acquisition_uuid == acq.uuid)
-        ).one()
-        foilhole_count = db.exec(
-            select(func.count())
-            .select_from(FoilHole)
-            .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
-            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
-            .where(Grid.acquisition_uuid == acq.uuid)
-        ).one()
-        micrograph_count = db.exec(
-            select(func.count())
-            .select_from(Micrograph)
-            .join(FoilHole, Micrograph.foilhole_uuid == FoilHole.uuid)
-            .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
-            .join(Grid, GridSquare.grid_uuid == Grid.uuid)
-            .where(Grid.acquisition_uuid == acq.uuid)
-        ).one()
+        grid_count = (
+            await db.execute(select(func.count()).select_from(Grid).where(Grid.acquisition_uuid == acq.uuid))
+        ).scalar_one()
+        gridsquare_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(GridSquare)
+                .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+                .where(Grid.acquisition_uuid == acq.uuid)
+            )
+        ).scalar_one()
+        foilhole_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(FoilHole)
+                .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
+                .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+                .where(Grid.acquisition_uuid == acq.uuid)
+            )
+        ).scalar_one()
+        micrograph_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(Micrograph)
+                .join(FoilHole, Micrograph.foilhole_uuid == FoilHole.uuid)
+                .join(GridSquare, FoilHole.gridsquare_uuid == GridSquare.uuid)
+                .join(Grid, GridSquare.grid_uuid == Grid.uuid)
+                .where(Grid.acquisition_uuid == acq.uuid)
+            )
+        ).scalar_one()
         results.append(
             {
                 "acquisition_uuid": acq.uuid,
@@ -97,7 +105,7 @@ def query_acquisition_progress(db: Session, acquisition_uuid: str | None = None)
     return results
 
 
-def query_instruction_updates(db: Session, since: datetime, agent_id: str | None = None) -> list[dict]:
+async def query_instruction_updates(db: AsyncSession, since: datetime, agent_id: str | None = None) -> list[dict]:
     query = select(AgentInstruction).where(
         (AgentInstruction.created_at > since)
         | (AgentInstruction.sent_at > since)
@@ -106,14 +114,20 @@ def query_instruction_updates(db: Session, since: datetime, agent_id: str | None
     if agent_id:
         query = query.where(AgentInstruction.agent_id == agent_id)
 
-    instructions = db.exec(query).all()
+    instructions = (await db.execute(query)).scalars().all()
     results = []
     for instr in instructions:
-        ack = db.exec(
-            select(AgentInstructionAcknowledgement)
-            .where(AgentInstructionAcknowledgement.instruction_id == instr.instruction_id)
-            .order_by(AgentInstructionAcknowledgement.created_at.desc())
-        ).first()
+        ack = (
+            (
+                await db.execute(
+                    select(AgentInstructionAcknowledgement)
+                    .where(AgentInstructionAcknowledgement.instruction_id == instr.instruction_id)
+                    .order_by(AgentInstructionAcknowledgement.created_at.desc())
+                )
+            )
+            .scalars()
+            .first()
+        )
         results.append(
             {
                 "instruction_id": instr.instruction_id,
@@ -130,7 +144,9 @@ def query_instruction_updates(db: Session, since: datetime, agent_id: str | None
     return results
 
 
-def query_processing_metrics(db: Session, since: datetime, acquisition_uuid: str | None = None) -> list[dict]:
+async def query_processing_metrics(
+    db: AsyncSession, since: datetime, acquisition_uuid: str | None = None
+) -> list[dict]:
     query = select(Micrograph).where(and_(Micrograph.updated_at.is_not(None), Micrograph.updated_at > since))
     if acquisition_uuid:
         query = (
@@ -140,7 +156,7 @@ def query_processing_metrics(db: Session, since: datetime, acquisition_uuid: str
             .where(Grid.acquisition_uuid == acquisition_uuid)
         )
 
-    micrographs = db.exec(query).all()
+    micrographs = (await db.execute(query)).scalars().all()
     return [
         {
             "micrograph_uuid": m.uuid,
@@ -155,12 +171,14 @@ def query_processing_metrics(db: Session, since: datetime, acquisition_uuid: str
     ]
 
 
-def query_agent_logs(db: Session, since_id: int, agent_id: str | None = None, limit: int = 200) -> list[dict]:
+async def query_agent_logs(
+    db: AsyncSession, since_id: int, agent_id: str | None = None, limit: int = 200
+) -> list[dict]:
     query = select(AgentLog).where(AgentLog.id > since_id).order_by(AgentLog.id).limit(limit)
     if agent_id:
         query = query.where(AgentLog.agent_id == agent_id)
 
-    logs = db.exec(query).all()
+    logs = (await db.execute(query)).scalars().all()
     return [
         {
             "id": log.id,

--- a/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
+++ b/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
@@ -23,28 +23,28 @@ def upgrade() -> None:
         sa.Column("session_id", sa.String(), nullable=False),
         sa.Column("timestamp", sa.DateTime(), nullable=False),
         sa.Column("level", sa.String(), nullable=False),
-        sa.Column("logger_name", sa.String(), nullable=False, server_default=""),
-        sa.Column("message", sa.String(), nullable=False, server_default=""),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("logger_name", sa.String(), nullable=False),
+        sa.Column("message", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("idx_agent_log_agent_id", "agentlog", ["agent_id"])
-    op.create_index("idx_agent_log_session_id", "agentlog", ["session_id"])
-    op.create_index("idx_agent_log_timestamp", "agentlog", ["timestamp"])
-    op.create_index("idx_agent_log_level", "agentlog", ["level"])
-    op.create_index("idx_agent_log_agent_id_id", "agentlog", ["agent_id", "id"])
+    op.create_index("ix_agentlog_agent_id", "agentlog", ["agent_id"])
+    op.create_index("ix_agentlog_session_id", "agentlog", ["session_id"])
+    op.create_index("ix_agentlog_timestamp", "agentlog", ["timestamp"])
+    op.create_index("ix_agentlog_level", "agentlog", ["level"])
+    op.create_index("ix_agentlog_agent_id_id", "agentlog", ["agent_id", "id"])
 
     op.add_column("micrograph", sa.Column("updated_at", sa.DateTime(), nullable=True))
-    op.create_index("idx_micrograph_updated_at", "micrograph", ["updated_at"])
+    op.create_index("ix_micrograph_updated_at", "micrograph", ["updated_at"])
 
 
 def downgrade() -> None:
-    op.drop_index("idx_micrograph_updated_at", table_name="micrograph")
+    op.drop_index("ix_micrograph_updated_at", table_name="micrograph")
     op.drop_column("micrograph", "updated_at")
 
-    op.drop_index("idx_agent_log_agent_id_id", table_name="agentlog")
-    op.drop_index("idx_agent_log_level", table_name="agentlog")
-    op.drop_index("idx_agent_log_timestamp", table_name="agentlog")
-    op.drop_index("idx_agent_log_session_id", table_name="agentlog")
-    op.drop_index("idx_agent_log_agent_id", table_name="agentlog")
+    op.drop_index("ix_agentlog_agent_id_id", table_name="agentlog")
+    op.drop_index("ix_agentlog_level", table_name="agentlog")
+    op.drop_index("ix_agentlog_timestamp", table_name="agentlog")
+    op.drop_index("ix_agentlog_session_id", table_name="agentlog")
+    op.drop_index("ix_agentlog_agent_id", table_name="agentlog")
     op.drop_table("agentlog")

--- a/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
+++ b/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
@@ -1,7 +1,7 @@
 """Add agent_log table and micrograph.updated_at column
 
 Revision ID: b3c4d5e6f7a8
-Revises: a1b2c3d4e5f6
+Revises: b2c3d4e5f6a7
 Create Date: 2026-03-27 12:00:00.000000
 
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "b3c4d5e6f7a8"
-down_revision = "a1b2c3d4e5f6"
+down_revision = "b2c3d4e5f6a7"
 branch_labels = None
 depends_on = None
 

--- a/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
+++ b/src/smartem_backend/migrations/versions/2026_03_27_1200-b3c4d5e6f7a8_add_agent_log_and_micrograph_updated_at.py
@@ -1,0 +1,50 @@
+"""Add agent_log table and micrograph.updated_at column
+
+Revision ID: b3c4d5e6f7a8
+Revises: a1b2c3d4e5f6
+Create Date: 2026-03-27 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "b3c4d5e6f7a8"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agentlog",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("agent_id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+        sa.Column("level", sa.String(), nullable=False),
+        sa.Column("logger_name", sa.String(), nullable=False, server_default=""),
+        sa.Column("message", sa.String(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_agent_log_agent_id", "agentlog", ["agent_id"])
+    op.create_index("idx_agent_log_session_id", "agentlog", ["session_id"])
+    op.create_index("idx_agent_log_timestamp", "agentlog", ["timestamp"])
+    op.create_index("idx_agent_log_level", "agentlog", ["level"])
+    op.create_index("idx_agent_log_agent_id_id", "agentlog", ["agent_id", "id"])
+
+    op.add_column("micrograph", sa.Column("updated_at", sa.DateTime(), nullable=True))
+    op.create_index("idx_micrograph_updated_at", "micrograph", ["updated_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_micrograph_updated_at", table_name="micrograph")
+    op.drop_column("micrograph", "updated_at")
+
+    op.drop_index("idx_agent_log_agent_id_id", table_name="agentlog")
+    op.drop_index("idx_agent_log_level", table_name="agentlog")
+    op.drop_index("idx_agent_log_timestamp", table_name="agentlog")
+    op.drop_index("idx_agent_log_session_id", table_name="agentlog")
+    op.drop_index("idx_agent_log_agent_id", table_name="agentlog")
+    op.drop_table("agentlog")

--- a/src/smartem_backend/model/database.py
+++ b/src/smartem_backend/model/database.py
@@ -229,6 +229,7 @@ class Micrograph(SQLModel, table=True, table_name="micrograph"):
     selection_distribution: str | None = Field(default=None)
     number_of_particles_picked: int | None = Field(default=None)
     pick_distribution: str | None = Field(default=None)
+    updated_at: datetime | None = Field(default=None, index=True)
     foilhole: FoilHole = Relationship(sa_relationship_kwargs={"back_populates": "micrographs"})
     quality_model_weights: list["QualityPredictionModelWeight"] = Relationship(
         back_populates="micrograph", cascade_delete=True
@@ -537,6 +538,18 @@ class AgentInstructionAcknowledgement(SQLModel, table=True):
     instruction: "AgentInstruction" = Relationship(sa_relationship_kwargs={"back_populates": "acknowledgements"})
 
 
+class AgentLog(SQLModel, table=True):
+    __table_args__ = {"extend_existing": True}
+    id: int | None = Field(default=None, primary_key=True)
+    agent_id: str = Field(index=True)
+    session_id: str = Field(index=True)
+    timestamp: datetime = Field(index=True)
+    level: str = Field(index=True)
+    logger_name: str = Field(default="")
+    message: str = Field(default="")
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
 def _create_db_and_tables(engine):
     # First drop all tables and enums
     with SQLModelSession(engine) as sess:
@@ -835,6 +848,16 @@ def _create_db_and_tables(engine):
                     "ON agentinstructionacknowledgement (processed_at);"
                 )
             )
+
+            # Agent log indexes
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_agent_id ON agentlog (agent_id);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_session_id ON agentlog (session_id);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_timestamp ON agentlog (timestamp);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_level ON agentlog (level);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_agent_id_id ON agentlog (agent_id, id);"))
+
+            # Micrograph updated_at index
+            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_micrograph_updated_at ON micrograph (updated_at);"))
 
             sess.commit()
         except Exception as e:

--- a/src/smartem_backend/model/database.py
+++ b/src/smartem_backend/model/database.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Column, text
+from sqlalchemy import Column, Index, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlmodel import Field, Relationship, SQLModel
 from sqlmodel import Session as SQLModelSession
@@ -539,7 +539,10 @@ class AgentInstructionAcknowledgement(SQLModel, table=True):
 
 
 class AgentLog(SQLModel, table=True):
-    __table_args__ = {"extend_existing": True}
+    __table_args__ = (
+        Index("ix_agentlog_agent_id_id", "agent_id", "id"),
+        {"extend_existing": True},
+    )
     id: int | None = Field(default=None, primary_key=True)
     agent_id: str = Field(index=True)
     session_id: str = Field(index=True)
@@ -850,14 +853,14 @@ def _create_db_and_tables(engine):
             )
 
             # Agent log indexes
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_agent_id ON agentlog (agent_id);"))
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_session_id ON agentlog (session_id);"))
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_timestamp ON agentlog (timestamp);"))
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_level ON agentlog (level);"))
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_agent_log_agent_id_id ON agentlog (agent_id, id);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_agentlog_agent_id ON agentlog (agent_id);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_agentlog_session_id ON agentlog (session_id);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_agentlog_timestamp ON agentlog (timestamp);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_agentlog_level ON agentlog (level);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_agentlog_agent_id_id ON agentlog (agent_id, id);"))
 
             # Micrograph updated_at index
-            sess.execute(text("CREATE INDEX IF NOT EXISTS idx_micrograph_updated_at ON micrograph (updated_at);"))
+            sess.execute(text("CREATE INDEX IF NOT EXISTS ix_micrograph_updated_at ON micrograph (updated_at);"))
 
             sess.commit()
         except Exception as e:

--- a/src/smartem_backend/model/frontend_sse_event.py
+++ b/src/smartem_backend/model/frontend_sse_event.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class FrontendEventType(str, Enum):
+    AGENT_STATUS = "agent.status"
+    ACQUISITION_PROGRESS = "acquisition.progress"
+    INSTRUCTION_LIFECYCLE = "instruction.lifecycle"
+    PROCESSING_METRIC = "processing.metric"
+    AGENT_LOG = "agent.log"
+    HEARTBEAT = "heartbeat"
+
+
+class AgentStatusData(BaseModel):
+    agent_id: str
+    status: str
+    session_id: str | None = None
+    acquisition_uuid: str | None = None
+    last_heartbeat_at: str | None = None
+    connection_count: int = 0
+
+
+class AcquisitionProgressData(BaseModel):
+    acquisition_uuid: str
+    grid_count: int = 0
+    gridsquare_count: int = 0
+    foilhole_count: int = 0
+    micrograph_count: int = 0
+    status: str = ""
+
+
+class InstructionLifecycleData(BaseModel):
+    instruction_id: str
+    agent_id: str
+    session_id: str
+    instruction_type: str
+    status: str
+    created_at: str
+    sent_at: str | None = None
+    acknowledged_at: str | None = None
+    ack_status: str | None = None
+
+
+class ProcessingMetricData(BaseModel):
+    micrograph_uuid: str
+    foilhole_uuid: str | None = None
+    total_motion: float | None = None
+    average_motion: float | None = None
+    ctf_max_resolution_estimate: float | None = None
+    number_of_particles_picked: int | None = None
+    number_of_particles_selected: int | None = None
+
+
+class AgentLogData(BaseModel):
+    agent_id: str
+    session_id: str
+    timestamp: str
+    level: str
+    logger_name: str
+    message: str
+
+
+class AgentLogEntry(BaseModel):
+    timestamp: datetime
+    level: str
+    logger_name: str
+    message: str
+
+
+class AgentLogBatchRequest(BaseModel):
+    logs: list[AgentLogEntry]
+
+
+class AgentLogBatchResponse(BaseModel):
+    stored: int

--- a/tests/smartem_agent/test_remote_log_handler.py
+++ b/tests/smartem_agent/test_remote_log_handler.py
@@ -1,0 +1,120 @@
+import logging
+import time
+from unittest.mock import MagicMock
+
+from smartem_agent.remote_log_handler import RemoteLogHandler
+
+
+class TestRemoteLogHandler:
+    def _make_handler(self, api_client=None, buffer_size=10, flush_interval=60.0):
+        client = api_client or MagicMock()
+        handler = RemoteLogHandler(
+            api_client=client,
+            agent_id="test-agent",
+            session_id="test-session",
+            buffer_size=buffer_size,
+            flush_interval=flush_interval,
+        )
+        return handler, client
+
+    def test_emit_buffers_records(self):
+        handler, client = self._make_handler(buffer_size=50)
+        record = logging.LogRecord(
+            name="test.logger",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test message",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        client.send_logs.assert_not_called()
+        handler.close()
+
+    def test_flush_on_buffer_full(self):
+        handler, client = self._make_handler(buffer_size=2)
+        for i in range(2):
+            record = logging.LogRecord(
+                name="test.logger",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg=f"message {i}",
+                args=None,
+                exc_info=None,
+            )
+            handler.emit(record)
+        client.send_logs.assert_called_once()
+        call_args = client.send_logs.call_args
+        assert call_args[0][0] == "test-agent"
+        assert call_args[0][1] == "test-session"
+        assert len(call_args[0][2]) == 2
+        handler.close()
+
+    def test_flush_sends_buffered_logs(self):
+        handler, client = self._make_handler()
+        record = logging.LogRecord(
+            name="mylogger",
+            level=logging.WARNING,
+            pathname="",
+            lineno=0,
+            msg="warning msg",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        handler.flush()
+        client.send_logs.assert_called_once()
+        log_entry = client.send_logs.call_args[0][2][0]
+        assert log_entry["level"] == "WARNING"
+        assert log_entry["logger_name"] == "mylogger"
+        assert log_entry["message"] == "warning msg"
+        handler.close()
+
+    def test_close_flushes_remaining(self):
+        handler, client = self._make_handler()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="final message",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        handler.close()
+        client.send_logs.assert_called()
+
+    def test_failed_send_does_not_raise(self):
+        client = MagicMock()
+        client.send_logs.side_effect = Exception("network error")
+        handler, _ = self._make_handler(api_client=client, buffer_size=1)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        handler.close()
+
+    def test_timed_flush(self):
+        handler, client = self._make_handler(flush_interval=0.2)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="timed test",
+            args=None,
+            exc_info=None,
+        )
+        handler.emit(record)
+        time.sleep(0.4)
+        client.send_logs.assert_called()
+        handler.close()

--- a/tests/smartem_backend/test_frontend_stream.py
+++ b/tests/smartem_backend/test_frontend_stream.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+from smartem_backend.model.frontend_sse_event import (
+    AgentLogBatchRequest,
+    AgentLogData,
+    AgentStatusData,
+    FrontendEventType,
+    ProcessingMetricData,
+)
+
+
+class TestFrontendEventModels:
+    def test_event_type_values(self):
+        assert FrontendEventType.AGENT_STATUS.value == "agent.status"
+        assert FrontendEventType.ACQUISITION_PROGRESS.value == "acquisition.progress"
+        assert FrontendEventType.INSTRUCTION_LIFECYCLE.value == "instruction.lifecycle"
+        assert FrontendEventType.PROCESSING_METRIC.value == "processing.metric"
+        assert FrontendEventType.AGENT_LOG.value == "agent.log"
+        assert FrontendEventType.HEARTBEAT.value == "heartbeat"
+
+    def test_agent_status_data(self):
+        data = AgentStatusData(
+            agent_id="agent-1",
+            status="online",
+            session_id="sess-1",
+            acquisition_uuid="acq-1",
+            last_heartbeat_at="2026-03-27T12:00:00",
+            connection_count=1,
+        )
+        assert data.agent_id == "agent-1"
+        assert data.status == "online"
+
+    def test_agent_status_data_minimal(self):
+        data = AgentStatusData(agent_id="agent-1", status="offline")
+        assert data.session_id is None
+        assert data.connection_count == 0
+
+    def test_processing_metric_data(self):
+        data = ProcessingMetricData(
+            micrograph_uuid="micro-1",
+            total_motion=1.5,
+            ctf_max_resolution_estimate=3.2,
+        )
+        assert data.micrograph_uuid == "micro-1"
+        assert data.average_motion is None
+
+    def test_agent_log_data(self):
+        data = AgentLogData(
+            agent_id="agent-1",
+            session_id="sess-1",
+            timestamp="2026-03-27T12:00:00",
+            level="INFO",
+            logger_name="smartem_agent.fs_watcher",
+            message="Batch processed",
+        )
+        dumped = data.model_dump()
+        assert dumped["level"] == "INFO"
+
+    def test_log_batch_request(self):
+        req = AgentLogBatchRequest(
+            logs=[
+                {
+                    "timestamp": datetime(2026, 3, 27, 12, 0, 0),
+                    "level": "INFO",
+                    "logger_name": "test",
+                    "message": "hello",
+                },
+                {
+                    "timestamp": datetime(2026, 3, 27, 12, 0, 1),
+                    "level": "ERROR",
+                    "logger_name": "test",
+                    "message": "oops",
+                },
+            ]
+        )
+        assert len(req.logs) == 2
+        assert req.logs[0].level == "INFO"
+        assert req.logs[1].level == "ERROR"


### PR DESCRIPTION
## Summary

- Add multiplexed SSE endpoint `GET /frontend/events/stream` with query param filtering (`acquisition_uuid`, `agent_id`, `event_types`)
- Add agent log ingestion endpoint `POST /agent/{agent_id}/session/{session_id}/logs` with batch support
- Add `RemoteLogHandler` on agent side that buffers and ships INFO+ logs every 5s
- Add `AgentLog` DB table with auto-increment cursor for efficient streaming, plus log retention cleanup (default 7 days)
- Add `Micrograph.updated_at` for processing metric change detection
- Set `updated_at` in consumer when motion correction and CTF results arrive

## Event types streamed

| Event | Source |
|---|---|
| `agent.status` | `AgentConnection` + `AgentSession` |
| `acquisition.progress` | COUNT queries on entity tables |
| `instruction.lifecycle` | `AgentInstruction` + acknowledgements |
| `processing.metric` | `Micrograph` where `updated_at > last_poll` |
| `agent.log` | `AgentLog` table (cursor-based) |
| `heartbeat` | Every 30s |

## DB migration

Alembic migration `b3c4d5e6f7a8` adds `agentlog` table and `micrograph.updated_at` column.

## Test plan

- [x] 12 new tests pass (6 RemoteLogHandler, 6 event model/serialisation)
- [x] All 72 existing tests pass
- [x] Pre-commit checks pass (ruff lint, ruff format, detect-secrets)
- [ ] Manual: `curl -N http://localhost:8000/frontend/events/stream` with backend running
- [ ] Manual: POST log batches, verify `agent.log` events in SSE stream
- [ ] Manual: Run agent with EPUPlayer, verify all event types

Closes #246
Related frontend work: DiamondLightSource/smartem-frontend#65