### PR TITLE
feat: API endpoints to publish processing-feedback events (#250)

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -56,6 +56,8 @@ from smartem_backend.model.http_request import (
     AtlasTileCreateRequest,
     AtlasTileUpdateRequest,
     AtlasUpdateRequest,
+    CtfEstimationCompletedRequest,
+    CtfEstimationRegisteredRequest,
     FoilHoleCreateRequest,
     FoilHoleUpdateRequest,
     GridCreateRequest,
@@ -65,6 +67,8 @@ from smartem_backend.model.http_request import (
     GridUpdateRequest,
     MicrographCreateRequest,
     MicrographUpdateRequest,
+    MotionCorrectionCompletedRequest,
+    MotionCorrectionRegisteredRequest,
     QualityPredictionCreateRequest,
     QualityPredictionModelCreateRequest,
     QualityPredictionModelUpdateRequest,
@@ -81,6 +85,7 @@ from smartem_backend.model.http_response import (
     GridSquareResponse,
     LatentRepresentationResponse,
     MicrographResponse,
+    ProcessingFeedbackPublishResponse,
     QualityMetricsResponse,
     QualityPredictionModelParameterResponse,
     QualityPredictionModelResponse,
@@ -96,6 +101,8 @@ from smartem_backend.mq_publisher import (
     publish_atlas_tile_deleted,
     publish_atlas_tile_updated,
     publish_atlas_updated,
+    publish_ctf_estimation_completed,
+    publish_ctf_estimation_registered,
     publish_foilhole_created,
     publish_foilhole_deleted,
     publish_foilhole_updated,
@@ -112,6 +119,8 @@ from smartem_backend.mq_publisher import (
     publish_micrograph_created,
     publish_micrograph_deleted,
     publish_micrograph_updated,
+    publish_motion_correction_completed,
+    publish_motion_correction_registered,
 )
 from smartem_backend.utils import setup_postgres_connection, setup_rabbitmq
 from smartem_common._version import __version__
@@ -1214,6 +1223,97 @@ def delete_micrograph(micrograph_uuid: str, db: SqlAlchemySession = DB_DEPENDENC
         logger.error(f"Failed to publish micrograph deleted event for ID: {micrograph_uuid}")
 
     return None
+
+
+def _require_micrograph(micrograph_uuid: str, db: SqlAlchemySession) -> None:
+    if not db.query(Micrograph).filter(Micrograph.uuid == micrograph_uuid).first():
+        raise HTTPException(status_code=404, detail="Micrograph not found")
+
+
+def _publish_or_502(success: bool, event_name: str, micrograph_uuid: str) -> ProcessingFeedbackPublishResponse:
+    if not success:
+        logger.error(f"Failed to publish {event_name} event for micrograph UUID: {micrograph_uuid}")
+        raise HTTPException(status_code=502, detail=f"Failed to publish {event_name} event to message queue")
+    return ProcessingFeedbackPublishResponse(published=True)
+
+
+@app.post(
+    "/micrographs/{micrograph_uuid}/motion_correction/completed",
+    response_model=ProcessingFeedbackPublishResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def publish_micrograph_motion_correction_completed(
+    micrograph_uuid: str,
+    payload: MotionCorrectionCompletedRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+):
+    """Publish a motion-correction-completed event for a micrograph to RabbitMQ."""
+    _require_micrograph(micrograph_uuid, db)
+    success = publish_motion_correction_completed(
+        micrograph_uuid=micrograph_uuid,
+        total_motion=payload.total_motion,
+        average_motion=payload.average_motion,
+    )
+    return _publish_or_502(success, "motion_correction_completed", micrograph_uuid)
+
+
+@app.post(
+    "/micrographs/{micrograph_uuid}/motion_correction/registered",
+    response_model=ProcessingFeedbackPublishResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def publish_micrograph_motion_correction_registered(
+    micrograph_uuid: str,
+    payload: MotionCorrectionRegisteredRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+):
+    """Publish a motion-correction-registered event for a micrograph to RabbitMQ."""
+    _require_micrograph(micrograph_uuid, db)
+    success = publish_motion_correction_registered(
+        micrograph_uuid=micrograph_uuid,
+        quality=payload.quality,
+        metric_name=payload.metric_name,
+    )
+    return _publish_or_502(success, "motion_correction_registered", micrograph_uuid)
+
+
+@app.post(
+    "/micrographs/{micrograph_uuid}/ctf_estimation/completed",
+    response_model=ProcessingFeedbackPublishResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def publish_micrograph_ctf_estimation_completed(
+    micrograph_uuid: str,
+    payload: CtfEstimationCompletedRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+):
+    """Publish a CTF-estimation-completed event for a micrograph to RabbitMQ."""
+    _require_micrograph(micrograph_uuid, db)
+    success = publish_ctf_estimation_completed(
+        micrograph_uuid=micrograph_uuid,
+        ctf_max_res=payload.ctf_max_res,
+    )
+    return _publish_or_502(success, "ctf_estimation_completed", micrograph_uuid)
+
+
+@app.post(
+    "/micrographs/{micrograph_uuid}/ctf_estimation/registered",
+    response_model=ProcessingFeedbackPublishResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def publish_micrograph_ctf_estimation_registered(
+    micrograph_uuid: str,
+    payload: CtfEstimationRegisteredRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+):
+    """Publish a CTF-estimation-registered event for a micrograph to RabbitMQ."""
+    _require_micrograph(micrograph_uuid, db)
+    success = publish_ctf_estimation_registered(
+        micrograph_uuid=micrograph_uuid,
+        quality=payload.quality,
+        metric_name=payload.metric_name,
+    )
+    return _publish_or_502(success, "ctf_estimation_registered", micrograph_uuid)
 
 
 @app.get("/foilholes/{foilhole_uuid}/micrographs", response_model=list[MicrographResponse])

--- a/src/smartem_backend/model/http_request.py
+++ b/src/smartem_backend/model/http_request.py
@@ -290,6 +290,28 @@ class MicrographUpdateRequest(MicrographBaseFields):
     pass
 
 
+# ============ Processing Feedback Request Models ============
+
+
+class MotionCorrectionCompletedRequest(BaseModel):
+    total_motion: float
+    average_motion: float
+
+
+class MotionCorrectionRegisteredRequest(BaseModel):
+    quality: bool
+    metric_name: str | None = None
+
+
+class CtfEstimationCompletedRequest(BaseModel):
+    ctf_max_res: float
+
+
+class CtfEstimationRegisteredRequest(BaseModel):
+    quality: bool
+    metric_name: str | None = None
+
+
 # ============ Quality Prediction Request Models ============
 
 

--- a/src/smartem_backend/model/http_response.py
+++ b/src/smartem_backend/model/http_response.py
@@ -286,3 +286,9 @@ class AgentInstructionAcknowledgementResponse(BaseModel):
         from_attributes=True,
         use_enum_values=True,
     )
+
+
+class ProcessingFeedbackPublishResponse(BaseModel):
+    """Confirmation that a processing-feedback event was published to RabbitMQ."""
+
+    published: bool

--- a/tests/smartem_backend/test_processing_feedback_endpoints.py
+++ b/tests/smartem_backend/test_processing_feedback_endpoints.py
@@ -1,0 +1,134 @@
+"""End-to-end checks for the processing-feedback publish endpoints (issue #250).
+
+These endpoints are thin wrappers: they verify the micrograph exists, then call
+one of the existing RabbitMQ publish helpers. Tests stub the DB dependency and
+monkeypatch the publish helpers so nothing real is touched.
+"""
+
+import os
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+os.environ["SKIP_DB_INIT"] = "true"
+
+import pytest
+from fastapi.testclient import TestClient
+
+from smartem_backend import api_server
+from smartem_backend.api_server import app, get_db
+
+
+@dataclass
+class _Captured:
+    name: str
+    kwargs: dict
+
+
+@pytest.fixture
+def captured():
+    return []
+
+
+@pytest.fixture
+def client(captured, monkeypatch):
+    def _fake_publish(name, return_value=True):
+        def _inner(**kwargs):
+            captured.append(_Captured(name=name, kwargs=kwargs))
+            return return_value
+
+        return _inner
+
+    monkeypatch.setattr(api_server, "publish_motion_correction_completed", _fake_publish("motion_completed"))
+    monkeypatch.setattr(api_server, "publish_motion_correction_registered", _fake_publish("motion_registered"))
+    monkeypatch.setattr(api_server, "publish_ctf_estimation_completed", _fake_publish("ctf_completed"))
+    monkeypatch.setattr(api_server, "publish_ctf_estimation_registered", _fake_publish("ctf_registered"))
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = object()
+
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as tc:
+            tc._db = db
+            yield tc
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+class TestMotionCorrectionCompleted:
+    endpoint = "/micrographs/abc-123/motion_correction/completed"
+
+    def test_happy_path(self, client, captured):
+        resp = client.post(self.endpoint, json={"total_motion": 1.5, "average_motion": 0.1})
+        assert resp.status_code == 202
+        assert resp.json() == {"published": True}
+        assert len(captured) == 1
+        assert captured[0].name == "motion_completed"
+        assert captured[0].kwargs == {
+            "micrograph_uuid": "abc-123",
+            "total_motion": 1.5,
+            "average_motion": 0.1,
+        }
+
+    def test_missing_micrograph_returns_404(self, client, captured):
+        client._db.query.return_value.filter.return_value.first.return_value = None
+        resp = client.post(self.endpoint, json={"total_motion": 1.5, "average_motion": 0.1})
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Micrograph not found"
+        assert captured == []
+
+    def test_publish_failure_returns_502(self, client, captured, monkeypatch):
+        monkeypatch.setattr(api_server, "publish_motion_correction_completed", lambda **_: False)
+        resp = client.post(self.endpoint, json={"total_motion": 1.5, "average_motion": 0.1})
+        assert resp.status_code == 502
+        assert "motion_correction_completed" in resp.json()["detail"]
+
+    def test_missing_body_field_returns_422(self, client):
+        resp = client.post(self.endpoint, json={"total_motion": 1.5})
+        assert resp.status_code == 422
+
+
+class TestMotionCorrectionRegistered:
+    endpoint = "/micrographs/abc-123/motion_correction/registered"
+
+    def test_happy_path_with_metric_name(self, client, captured):
+        resp = client.post(self.endpoint, json={"quality": True, "metric_name": "drift"})
+        assert resp.status_code == 202
+        assert captured[0].kwargs == {
+            "micrograph_uuid": "abc-123",
+            "quality": True,
+            "metric_name": "drift",
+        }
+
+    def test_metric_name_optional(self, client, captured):
+        resp = client.post(self.endpoint, json={"quality": False})
+        assert resp.status_code == 202
+        assert captured[0].kwargs == {
+            "micrograph_uuid": "abc-123",
+            "quality": False,
+            "metric_name": None,
+        }
+
+
+class TestCtfEstimationCompleted:
+    endpoint = "/micrographs/abc-123/ctf_estimation/completed"
+
+    def test_happy_path(self, client, captured):
+        resp = client.post(self.endpoint, json={"ctf_max_res": 3.2})
+        assert resp.status_code == 202
+        assert captured[0].name == "ctf_completed"
+        assert captured[0].kwargs == {"micrograph_uuid": "abc-123", "ctf_max_res": 3.2}
+
+
+class TestCtfEstimationRegistered:
+    endpoint = "/micrographs/abc-123/ctf_estimation/registered"
+
+    def test_happy_path(self, client, captured):
+        resp = client.post(self.endpoint, json={"quality": True, "metric_name": "astigmatism"})
+        assert resp.status_code == 202
+        assert captured[0].name == "ctf_registered"
+        assert captured[0].kwargs == {
+            "micrograph_uuid": "abc-123",
+            "quality": True,
+            "metric_name": "astigmatism",
+        }


### PR DESCRIPTION
## Summary

Closes #250.

Four new POST endpoints under `/micrographs/{micrograph_uuid}` wrap the existing RabbitMQ publish helpers so callers can trigger processing-feedback events via HTTP instead of publishing to RabbitMQ directly.

| Endpoint | Body | Wraps |
|----------|------|-------|
| `POST /micrographs/{uuid}/motion_correction/completed` | `{total_motion, average_motion}` | `publish_motion_correction_completed` |
| `POST /micrographs/{uuid}/motion_correction/registered` | `{quality, metric_name?}` | `publish_motion_correction_registered` |
| `POST /micrographs/{uuid}/ctf_estimation/completed` | `{ctf_max_res}` | `publish_ctf_estimation_completed` |
| `POST /micrographs/{uuid}/ctf_estimation/registered` | `{quality, metric_name?}` | `publish_ctf_estimation_registered` |

## Semantics

- Validates that the `micrograph_uuid` exists in the database. Unknown UUID → `404 Not Found` (safety net for a tool that would otherwise silently enqueue events for non-existent micrographs).
- On success → `202 Accepted` with `{"published": true}`. No DB write; these endpoints are fire-and-forget event sinks.
- On publish failure (e.g. RabbitMQ unreachable) → `502 Bad Gateway` with the event name in the detail, and an `ERROR` log line. Existing publish helpers already return `False` on failure — this plumbs that signal through to the caller instead of swallowing it.

Alternative shape considered: a single `POST /micrographs/{uuid}/processing_feedback` with a discriminated-union body. Rejected — the nested-resource layout reads better in the OpenAPI spec and in generated clients.

## New testing infrastructure

This PR introduces the first FastAPI `TestClient`-based tests in the repo, using `app.dependency_overrides[get_db]` plus `monkeypatch` on the publish helpers. The pattern needs no PostgreSQL and no RabbitMQ and exercises the full handler path (Pydantic validation, path/body parsing, response serialisation).

Follow-up issue to expand this coverage to the rest of the API is filed separately.

## Test plan

- [x] `uv run pytest tests/` — 139 passed, 3 skipped, 0 failures (+8 new tests for these endpoints).
- [x] Ruff lint + format on all changed files — clean.
- [ ] Manual smoke once RabbitMQ is reachable: hit each endpoint against a real micrograph and observe the event in the queue.