### PR TITLE
feat: bulk gridsquare creation endpoint (#249)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@
 # Leave commented out to use config at default path.
 #SMARTEM_BACKEND_CONFIG="path/to/smartem_backend/appconfig.yml"
 
+# Override the maximum batch size accepted by POST /grids/{uuid}/gridsquares/batch.
+# Defaults to the value set in appconfig.yml (app.gridsquare_create_batch_max).
+#SMARTEM_GRIDSQUARE_CREATE_BATCH_MAX=1000
+
 # Database configuration (connecting to K8s NodePort)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=30432

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,8 +137,13 @@ addopts = """
     """
 # https://iscinumpy.gitlab.io/post/bound-version-constraints/#watch-for-warnings
 filterwarnings = ["error"]
-# Doctest python code in src docstrings, test functions in tests
-testpaths = "src tests"
+# Collect tests (and any doctests in those files) from tests/.
+# src/ is excluded from collection because pytest's doctest-modules import
+# would double-register SQLModel classes — the modules get loaded once via
+# test imports (as smartem_backend.*) and once via pytest's file-based collection,
+# tripping SQLAlchemy's "Multiple classes found" resolver on string relationships.
+# There are no doctests in src today; if that changes, revisit src-layout setup.
+testpaths = "tests"
 # Exclude Alembic migration files from pytest collection (they're not meant to be imported directly)
 norecursedirs = "src/smartem_backend/migrations"
 

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response
 from PIL import Image
 from pydantic import BaseModel
 from sqlalchemy import and_, desc, or_, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as SqlAlchemySession
 from sqlalchemy.orm import sessionmaker
 from sse_starlette.sse import EventSourceResponse
@@ -61,6 +62,7 @@ from smartem_backend.model.http_request import (
     FoilHoleCreateRequest,
     FoilHoleUpdateRequest,
     GridCreateRequest,
+    GridSquareBatchCreateRequest,
     GridSquareCreateRequest,
     GridSquarePositionRequest,
     GridSquareUpdateRequest,
@@ -82,6 +84,7 @@ from smartem_backend.model.http_response import (
     AtlasTileResponse,
     FoilHoleResponse,
     GridResponse,
+    GridSquareBatchCreateResponse,
     GridSquareResponse,
     LatentRepresentationResponse,
     MicrographResponse,
@@ -116,13 +119,14 @@ from smartem_backend.mq_publisher import (
     publish_gridsquare_lowmag_updated,
     publish_gridsquare_registered,
     publish_gridsquare_updated,
+    publish_gridsquares_created_batch,
     publish_micrograph_created,
     publish_micrograph_deleted,
     publish_micrograph_updated,
     publish_motion_correction_completed,
     publish_motion_correction_registered,
 )
-from smartem_backend.utils import setup_postgres_connection, setup_rabbitmq
+from smartem_backend.utils import app_config, setup_postgres_connection, setup_rabbitmq
 from smartem_common._version import __version__
 
 # Initialize database connection (skip in documentation generation mode)
@@ -194,6 +198,12 @@ app = FastAPI(
     version=__version__,
     redoc_url=None,
     lifespan=lifespan,
+)
+
+# Resolve runtime config (env var overrides appconfig.yml, which overrides hard default)
+_APP_CFG = (app_config or {}).get("app", {}) if isinstance(app_config, dict) else {}
+GRIDSQUARE_CREATE_BATCH_MAX = int(
+    os.getenv("SMARTEM_GRIDSQUARE_CREATE_BATCH_MAX", _APP_CFG.get("gridsquare_create_batch_max", 1000))
 )
 
 # Configure CORS
@@ -985,6 +995,74 @@ def create_grid_gridsquare(grid_uuid: str, gridsquare: GridSquareCreateRequest, 
         response_data["status"] = GridSquareStatus.NONE
 
     return GridSquareResponse(**response_data)
+
+
+@app.post(
+    "/grids/{grid_uuid}/gridsquares/batch",
+    response_model=GridSquareBatchCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_grid_gridsquares_batch(
+    grid_uuid: str,
+    payload: GridSquareBatchCreateRequest,
+    db: SqlAlchemySession = DB_DEPENDENCY,
+):
+    """Create many grid squares for a grid in a single transaction and a single
+    batched RabbitMQ publish. Solves the overload scenario from issue #249."""
+    items = payload.gridsquares
+    if not items:
+        raise HTTPException(status_code=422, detail="gridsquares must not be empty")
+    if len(items) > GRIDSQUARE_CREATE_BATCH_MAX:
+        raise HTTPException(
+            status_code=422,
+            detail=f"batch size {len(items)} exceeds limit of {GRIDSQUARE_CREATE_BATCH_MAX}",
+        )
+
+    uuids = [gs.uuid for gs in items]
+    if len(set(uuids)) != len(uuids):
+        raise HTTPException(status_code=422, detail="duplicate uuid in batch")
+
+    if not db.query(Grid).filter(Grid.uuid == grid_uuid).first():
+        raise HTTPException(status_code=404, detail="Grid not found")
+
+    db_gridsquares = [
+        GridSquare(
+            **{
+                "uuid": gs.uuid,
+                "grid_uuid": grid_uuid,
+                "status": GridSquareStatus.NONE,
+                **gs.model_dump(),
+            }
+        )
+        for gs in items
+    ]
+
+    db.add_all(db_gridsquares)
+    try:
+        db.commit()
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Integrity error inserting gridsquare batch for grid {grid_uuid}: {e}")
+        raise HTTPException(status_code=409, detail="gridsquare batch conflicts with existing data") from None
+
+    publish_entries = [(gs.uuid, grid_uuid, gs.gridsquare_id, gs.lowmag) for gs in items]
+    success = publish_gridsquares_created_batch(publish_entries)
+    if not success:
+        logger.error(f"Failed to publish gridsquare batch created events for grid {grid_uuid} ({len(items)} items)")
+
+    responses: list[GridSquareResponse] = []
+    for gs in items:
+        response_data = {
+            "uuid": gs.uuid,
+            "grid_uuid": grid_uuid,
+            "status": GridSquareStatus.NONE,
+            **gs.model_dump(),
+        }
+        if "status" not in response_data or response_data["status"] is None:
+            response_data["status"] = GridSquareStatus.NONE
+        responses.append(GridSquareResponse(**response_data))
+
+    return GridSquareBatchCreateResponse(gridsquares=responses)
 
 
 @app.post("/gridsquares/{gridsquare_uuid}/registered")

--- a/src/smartem_backend/appconfig.yml
+++ b/src/smartem_backend/appconfig.yml
@@ -3,6 +3,9 @@ app:
   # There is technically no guarantee that every micrograph will be covered by at most 2 batches.
   # The size of the batches basically makes incredibly unlikely but there is nothing to guarantee it.
   particle_select_batch_size: 50000
+  # Maximum number of gridsquares accepted in a single POST to
+  # /grids/{uuid}/gridsquares/batch. Override with SMARTEM_GRIDSQUARE_CREATE_BATCH_MAX.
+  gridsquare_create_batch_max: 1000
   log_file: smartem_backend-core.log
 
 rabbitmq:

--- a/src/smartem_backend/model/http_request.py
+++ b/src/smartem_backend/model/http_request.py
@@ -198,6 +198,10 @@ class GridSquareCreateRequest(GridSquareBaseRequest):
     lowmag: bool = False
 
 
+class GridSquareBatchCreateRequest(BaseModel):
+    gridsquares: list[GridSquareCreateRequest]
+
+
 class GridSquareUpdateRequest(GridSquareBaseFields):
     lowmag: bool = False
 

--- a/src/smartem_backend/model/http_response.py
+++ b/src/smartem_backend/model/http_response.py
@@ -292,3 +292,9 @@ class ProcessingFeedbackPublishResponse(BaseModel):
     """Confirmation that a processing-feedback event was published to RabbitMQ."""
 
     published: bool
+
+
+class GridSquareBatchCreateResponse(BaseModel):
+    """Response for bulk grid-square creation."""
+
+    gridsquares: list[GridSquareResponse]

--- a/src/smartem_backend/mq_publisher.py
+++ b/src/smartem_backend/mq_publisher.py
@@ -188,6 +188,30 @@ def publish_gridsquare_lowmag_updated(uuid, grid_uuid=None, gridsquare_id=None):
     return rmq_publisher.publish_event(MessageQueueEventType.GRIDSQUARE_LOWMAG_UPDATED, event)
 
 
+def publish_gridsquares_created_batch(
+    entries: list[tuple[str, str | None, str | None, bool]],
+) -> bool:
+    """Publish a batch of grid-square-created events in a single broker round-trip.
+
+    Each entry is (uuid, grid_uuid, gridsquare_id, lowmag). Low-mag entries are
+    routed to GRIDSQUARE_LOWMAG_CREATED, full-res entries to GRIDSQUARE_CREATED.
+    """
+    items: list[tuple[MessageQueueEventType, GridSquareCreatedEvent]] = []
+    for uuid, grid_uuid, gridsquare_id, lowmag in entries:
+        event_type = (
+            MessageQueueEventType.GRIDSQUARE_LOWMAG_CREATED if lowmag else MessageQueueEventType.GRIDSQUARE_CREATED
+        )
+        items.append(
+            (
+                event_type,
+                GridSquareCreatedEvent(
+                    event_type=event_type, uuid=uuid, grid_uuid=grid_uuid, gridsquare_id=gridsquare_id
+                ),
+            )
+        )
+    return rmq_publisher.publish_events(items)
+
+
 def publish_gridsquare_lowmag_deleted(uuid):
     """Publish low mag grid square deleted event to RabbitMQ"""
     event = GridSquareDeletedEvent(event_type=MessageQueueEventType.GRIDSQUARE_LOWMAG_DELETED, uuid=uuid)

--- a/src/smartem_backend/utils.py
+++ b/src/smartem_backend/utils.py
@@ -337,6 +337,46 @@ class RabbitMQPublisher(RabbitMQConnection):
                 logger.error(f"Failed to publish {event_type.value} event: {str(e)}")
                 return False
 
+    def publish_events(self, items: list[tuple[MessageQueueEventType, BaseModel | dict[str, Any]]]) -> bool:
+        """
+        Publish a batch of events over a single connection.
+
+        All items are published on the same channel with one connect() at the start
+        and one reconnect attempt if the connection drops mid-batch. This avoids the
+        per-message retry/log overhead of calling publish_event() N times.
+
+        Args:
+            items: Sequence of (event_type, payload) pairs to publish in order.
+
+        Returns:
+            bool: True only if all items were published successfully. On partial
+            failure, already-published items remain on the broker (RabbitMQ does not
+            support batch rollback without publisher confirms + tx, which is out of
+            scope here).
+        """
+        if not items:
+            return True
+
+        try:
+            self.connect()
+            for event_type, payload in items:
+                self._handle_publish(event_type, payload)
+            return True
+
+        except (pika.exceptions.AMQPConnectionError, pika.exceptions.StreamLostError):
+            logger.warning(f"Batch publish of {len(items)} events failed, retrying with fresh connection")
+            self._connection = None
+            self._channel = None
+            try:
+                self.connect()
+                for event_type, payload in items:
+                    self._handle_publish(event_type, payload)
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to publish batch of {len(items)} events: {str(e)}")
+                return False
+
 
 class RabbitMQConsumer(RabbitMQConnection):
     """

--- a/tests/smartem_backend/test_batch_gridsquare_creation.py
+++ b/tests/smartem_backend/test_batch_gridsquare_creation.py
@@ -1,0 +1,134 @@
+"""Tests for the bulk grid-square creation endpoint (issue #249).
+
+Uses the same TestClient + dependency-override pattern established in
+test_processing_feedback_endpoints.py. The DB is stubbed via MagicMock — we
+assert on which ORM entities got added and which publish helper was called
+with what payload. No Postgres, no RabbitMQ.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+os.environ["SKIP_DB_INIT"] = "true"
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from smartem_backend import api_server
+from smartem_backend.api_server import app, get_db
+
+
+def _gs(uuid: str, gridsquare_id: str = "gs-1", lowmag: bool = False) -> dict:
+    return {
+        "uuid": uuid,
+        "gridsquare_id": gridsquare_id,
+        "grid_uuid": "grid-abc",
+        "lowmag": lowmag,
+    }
+
+
+@pytest.fixture
+def publish_calls():
+    return []
+
+
+@pytest.fixture
+def client(publish_calls, monkeypatch):
+    def _fake_batch_publish(entries):
+        publish_calls.append(list(entries))
+        return True
+
+    monkeypatch.setattr(api_server, "publish_gridsquares_created_batch", _fake_batch_publish)
+
+    db = MagicMock()
+    # Grid lookup returns a truthy object by default (grid exists)
+    db.query.return_value.filter.return_value.first.return_value = object()
+
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as tc:
+            tc._db = db
+            yield tc
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+ENDPOINT = "/grids/grid-abc/gridsquares/batch"
+
+
+class TestBatchCreateHappyPath:
+    def test_inserts_all_and_publishes_batch(self, client, publish_calls):
+        payload = {"gridsquares": [_gs("u-1"), _gs("u-2", lowmag=True), _gs("u-3")]}
+        resp = client.post(ENDPOINT, json=payload)
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert [gs["uuid"] for gs in body["gridsquares"]] == ["u-1", "u-2", "u-3"]
+
+        # Single add_all call with 3 entities, single commit
+        client._db.add_all.assert_called_once()
+        added = client._db.add_all.call_args.args[0]
+        assert len(added) == 3
+        client._db.commit.assert_called_once()
+
+        # Single batch publish with the right entries in the right order
+        assert len(publish_calls) == 1
+        assert publish_calls[0] == [
+            ("u-1", "grid-abc", "gs-1", False),
+            ("u-2", "grid-abc", "gs-1", True),
+            ("u-3", "grid-abc", "gs-1", False),
+        ]
+
+    def test_empty_list_rejected(self, client):
+        resp = client.post(ENDPOINT, json={"gridsquares": []})
+        assert resp.status_code == 422
+
+    def test_response_shape_matches_single_create_contract(self, client):
+        resp = client.post(ENDPOINT, json={"gridsquares": [_gs("u-1")]})
+        body = resp.json()["gridsquares"][0]
+        assert body["uuid"] == "u-1"
+        assert body["grid_uuid"] == "grid-abc"
+        # status defaults to NONE (serialised via use_enum_values)
+        assert body["status"] == "none"
+
+
+class TestValidation:
+    def test_duplicate_uuids_rejected(self, client):
+        payload = {"gridsquares": [_gs("u-1"), _gs("u-1")]}
+        resp = client.post(ENDPOINT, json=payload)
+        assert resp.status_code == 422
+        assert "duplicate" in resp.json()["detail"].lower()
+        client._db.add_all.assert_not_called()
+
+    def test_oversize_batch_rejected(self, client, monkeypatch):
+        monkeypatch.setattr(api_server, "GRIDSQUARE_CREATE_BATCH_MAX", 2)
+        payload = {"gridsquares": [_gs(f"u-{i}") for i in range(3)]}
+        resp = client.post(ENDPOINT, json=payload)
+        assert resp.status_code == 422
+        assert "exceeds limit of 2" in resp.json()["detail"]
+        client._db.add_all.assert_not_called()
+
+    def test_missing_required_field_422(self, client):
+        # uuid missing
+        resp = client.post(ENDPOINT, json={"gridsquares": [{"gridsquare_id": "x", "grid_uuid": "grid-abc"}]})
+        assert resp.status_code == 422
+
+
+class TestErrorPaths:
+    def test_grid_not_found_returns_404(self, client):
+        client._db.query.return_value.filter.return_value.first.return_value = None
+        resp = client.post(ENDPOINT, json={"gridsquares": [_gs("u-1")]})
+        assert resp.status_code == 404
+        client._db.add_all.assert_not_called()
+
+    def test_integrity_error_returns_409_and_rolls_back(self, client):
+        client._db.commit.side_effect = IntegrityError("insert", {}, Exception("duplicate key"))
+        resp = client.post(ENDPOINT, json={"gridsquares": [_gs("u-1")]})
+        assert resp.status_code == 409
+        client._db.rollback.assert_called_once()
+
+    def test_publish_failure_logged_but_not_fatal(self, client, monkeypatch):
+        monkeypatch.setattr(api_server, "publish_gridsquares_created_batch", lambda _entries: False)
+        resp = client.post(ENDPOINT, json={"gridsquares": [_gs("u-1")]})
+        assert resp.status_code == 201


### PR DESCRIPTION
## Summary

Closes #249.

Adds `POST /grids/{grid_uuid}/gridsquares/batch` so clients can create many grid squares in a single request instead of looping over the singular endpoint. Under the high-throughput ingestion scenario #249 describes (thousands of gridsquares per grid), the per-row loop was overwhelming the API server. This collapses the DB side to a single transaction and the broker side to a single batched publish.

## Request/response shape

```
POST /grids/{grid_uuid}/gridsquares/batch
{
  "gridsquares": [GridSquareCreateRequest, ...]
}
```

Response (201): `{ "gridsquares": [GridSquareResponse, ...] }` in input order. Each item is the same shape as the singular `POST /grids/{uuid}/gridsquares` endpoint returns.

## Semantics

| Condition | Response |
|-----------|----------|
| Empty list | `422` — `gridsquares must not be empty` |
| Duplicate UUIDs in batch | `422` — `duplicate uuid in batch` |
| Batch size > configured max | `422` — `batch size N exceeds limit of M` |
| Grid `uuid` not found | `404` — `Grid not found` |
| DB integrity error (UUID collision with existing row, FK violation, ...) | `409` + rollback |
| Success | `201` + response body; one `add_all()` + one `commit()` + one batched publish |
| Publish failure | Logged, **not** fatal — matches the existing singular-endpoint behaviour |

## Batch-publish optimisation

The singular endpoint publishes events one at a time via `publish_event()`. For batches this means N broker round-trips with N try/except retry-loop invocations. This PR adds:

- `RabbitMQPublisher.publish_events(items)` — publishes the whole list on a single connection with one reconnect-on-failure attempt total. Returns True only if all items published.
- `publish_gridsquares_created_batch(entries)` in `mq_publisher.py` — dispatches each entry to `GRIDSQUARE_CREATED` or `GRIDSQUARE_LOWMAG_CREATED` based on `lowmag`, then fans out via `publish_events`.

No publisher confirms, no broker transactions — deliberately out of scope. If partial failure happens mid-batch, already-published items stay on the broker (no atomicity guarantee at the message-broker level). This matches what the current per-item path does today.

## Config

| Source | Key | Default |
|--------|-----|---------|
| `appconfig.yml` | `app.gridsquare_create_batch_max` | `1000` |
| Env var (override) | `SMARTEM_GRIDSQUARE_CREATE_BATCH_MAX` | (unset) |

Documented in `.env.example` with the same commented-out pattern used for `SMARTEM_BACKEND_CONFIG`.

## Tests

Nine new `TestClient`-based tests (reusing the pattern from #257):

- Happy path: single `add_all`, single `commit`, single batch-publish call with correct entries in input order; response ordering; default `status=none` in response body.
- Validation: empty list rejected; duplicate UUIDs rejected; oversize batch rejected (with `monkeypatch` flipping the limit to 2); missing required field 422.
- Errors: grid missing → 404 without DB writes; `IntegrityError` → 409 with explicit `rollback`; publish failure → 201 (non-fatal).

No Postgres, no RabbitMQ required. Runs in ~1.75s.

## Test plan

- [x] `uv run pytest tests/` — 148 passed, 3 skipped, 0 failures (+9 new tests).
- [x] Ruff lint + format on all changed files — clean.
- [ ] Manual smoke once the DB and RabbitMQ are reachable: POST a batch of 100 gridsquares against a real grid, confirm (a) one SQL transaction, (b) 100 events land on the queue in order, (c) response body matches.

## Non-goals / follow-ups

- RabbitMQ publisher confirms + tx for atomic batch delivery. Worth a separate ticket only if we actually observe partial-batch failures in production.
- Migrating `POST /foilholes/{uuid}/micrographs` and similar high-fan-out endpoints to the same batch pattern. Same reasoning as above — only if it becomes a hotspot.