### PR TITLE
fix: populate ATLAS_CREATED event id from atlas_id, not name (#254)

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -662,7 +662,7 @@ def create_grid_atlas(grid_uuid: str, atlas: AtlasCreateRequest, db: SqlAlchemyS
     db.add(db_atlas)
     db.commit()
 
-    success = publish_atlas_created(uuid=db_atlas.uuid, id=db_atlas.name, grid_uuid=db_atlas.grid_uuid)
+    success = publish_atlas_created(uuid=db_atlas.uuid, id=db_atlas.atlas_id, grid_uuid=db_atlas.grid_uuid)
     if not success:
         logger.error(f"Failed to publish atlas created event for UUID: {db_atlas.uuid}")
 

--- a/tests/smartem_backend/test_atlas_event_contract.py
+++ b/tests/smartem_backend/test_atlas_event_contract.py
@@ -1,0 +1,73 @@
+"""Regression guards for the atlas RabbitMQ event field contract (issue #254).
+
+`publish_atlas_created` used to receive `id=db_atlas.name` while the paired
+`publish_atlas_updated` received `id=db_atlas.atlas_id`. Downstream consumers
+saw two different things under the same nominal `id` field. The fix is trivial
+(use `atlas_id` in both) but there is no test asserting the contract, so the
+bug could regress silently. These tests lock the contract in place.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+os.environ["SKIP_DB_INIT"] = "true"
+
+import pytest
+from fastapi.testclient import TestClient
+
+from smartem_backend import api_server
+from smartem_backend.api_server import app, get_db
+
+
+@pytest.fixture
+def captured():
+    return {}
+
+
+@pytest.fixture
+def client(captured, monkeypatch):
+    def _capture(name):
+        def _inner(**kwargs):
+            captured[name] = kwargs
+            return True
+
+        return _inner
+
+    monkeypatch.setattr(api_server, "publish_atlas_created", _capture("atlas_created"))
+    monkeypatch.setattr(api_server, "publish_atlas_updated", _capture("atlas_updated"))
+
+    db = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as tc:
+            tc._db = db
+            yield tc
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _atlas_payload(**overrides) -> dict:
+    base = {
+        "uuid": "atlas-uuid-1",
+        "grid_uuid": "grid-uuid-1",
+        "atlas_id": "ATLAS_001",
+        "name": "Session 42 atlas",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestAtlasCreatedEventContract:
+    """`id` in the ATLAS_CREATED event must carry `atlas_id`, not `name`."""
+
+    def test_id_is_atlas_id_not_name(self, client, captured):
+        payload = _atlas_payload(atlas_id="ATLAS_001", name="some-display-name")
+        resp = client.post("/grids/grid-uuid-1/atlas", json=payload)
+        assert resp.status_code == 201, resp.text
+
+        call = captured.get("atlas_created")
+        assert call is not None, "publish_atlas_created was not called"
+        assert call["id"] == "ATLAS_001"
+        assert call["id"] != "some-display-name"
+        assert call["uuid"] == "atlas-uuid-1"
+        assert call["grid_uuid"] == "grid-uuid-1"


### PR DESCRIPTION
## Summary

Closes #254.

`publish_atlas_created` in the `POST /grids/{uuid}/atlas` handler was receiving `id=db_atlas.name`, while the paired `publish_atlas_updated` in `PUT /atlases/{uuid}` receives `id=db_atlas.atlas_id`. Same entity, same event family, different meaning — consumers of the `ATLAS_CREATED` RabbitMQ event would receive the human-readable atlas *name* in a field labelled `id`, breaking any code expecting the EPU-side identifier.

## Impact

- In-repo consumer (`handle_atlas_created` in `consumer.py`) only logs the event, so there has been no runtime symptom in the system-under-test.
- External recommendation / processing plugins subscribing to `ATLAS_CREATED` would silently see wrong identifiers — a correctness bug with no loud signal.

## Fix

One-line change in `api_server.py`: align with the neighbouring `publish_atlas_updated` call, using `db_atlas.atlas_id`.

## Regression guard

New test `tests/smartem_backend/test_atlas_event_contract.py` uses the TestClient pattern to POST a create request with distinct `atlas_id` and `name` values, captures the `publish_atlas_created` kwargs via `monkeypatch`, and asserts `id == atlas_id` (and explicitly `!= name`). Sanity-checked by temporarily reverting the fix: the test fails with the exact expected diff.

## Test plan

- [x] `uv run pytest tests/` — 149 passed, 3 skipped, 0 failed (+1 new test).
- [x] Ruff lint + format — clean.
- [x] Reverted-fix sanity check — test fails loudly as expected.

## Notes

Scoped deliberately tight: this PR does **not** refactor or add coverage for other atlas-event paths, nor does it change the event schema. If the `id`/`atlas_id` naming ambiguity on the event model (`AtlasCreatedEvent.id`) is worth cleaning up, that's a separate conversation.