### PR TITLE
fix(ci): remove continue-on-error from gitleaks jobs

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yml
+++ b/.github/workflows/leaked-secrets-scan.yml
@@ -13,7 +13,6 @@ jobs:
   gitleaks-licensed:
     name: gitleaks (licensed)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Check for license
         id: license
@@ -39,7 +38,6 @@ jobs:
   gitleaks-cli:
     name: gitleaks (CLI)
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       GITLEAKS_VERSION: '8.30.0'
     steps:


### PR DESCRIPTION
## Summary

Both `gitleaks-licensed` and `gitleaks-cli` jobs in `leaked-secrets-scan.yml` had `continue-on-error: true`, which meant a real secret leak finding would log but not fail the workflow — defeating the purpose of the scan.

## Changes

- Remove `continue-on-error: true` from `gitleaks-licensed` job
- Remove `continue-on-error: true` from `gitleaks-cli` job

Default (`false`) now applies, so gitleaks findings will block the build as intended.

## Testing

Workflow will run on this PR; a clean scan confirms no regression.