### PR TITLE
feat: migrate predictions and CLI helpers to AsyncSession

### DIFF
--- a/src/smartem_backend/cli/initialise_prediction_model_weights.py
+++ b/src/smartem_backend/cli/initialise_prediction_model_weights.py
@@ -1,6 +1,8 @@
+import asyncio
+
 import typer
-from sqlalchemy.engine import Engine
-from sqlmodel import Session, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from smartem_backend.model.database import (
     CurrentQualityPredictionModelWeight,
@@ -9,43 +11,44 @@ from smartem_backend.model.database import (
     QualityPredictionModel,
     QualityPredictionModelWeight,
 )
-from smartem_backend.utils import get_db_engine, logger
+from smartem_backend.utils import logger, setup_postgres_async_connection
 
 
-def initialise_all_models_for_grid(grid_uuid: str, engine: Engine = None) -> None:
-    """
-    Initialise prediction model weights for all available models for a specific grid.
+def _make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=engine, class_=AsyncSession, autocommit=False, autoflush=False, expire_on_commit=False
+    )
 
-    Args:
-        grid_uuid: UUID of the grid to initialise weights for
-        engine: Optional database engine (uses singleton if not provided)
-    """
+
+async def initialise_all_models_for_grid(grid_uuid: str, engine: AsyncEngine | None = None) -> None:
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
-        # Get all available prediction models
-        models = sess.exec(select(QualityPredictionModel)).all()
-        # get all metrics
-        # each weight will be initialised against each metric so that they can be adjusted independently
-        metrics = sess.exec(select(QualityMetric)).all()
+    async with session_factory() as sess:
+        models = (await sess.execute(select(QualityPredictionModel))).scalars().all()
+        metrics = (await sess.execute(select(QualityMetric))).scalars().all()
 
         if not models:
             logger.warning(f"No prediction models found to initialise for grid {grid_uuid}")
             return
 
-        # Initialise weights for each model
         default_weight = 1 / len(models)
         for metric in metrics:
             for model in models:
-                # Check if weight already exists for this grid-model combination
-                existing_weight = sess.exec(
-                    select(QualityPredictionModelWeight).where(
-                        QualityPredictionModelWeight.grid_uuid == grid_uuid,
-                        QualityPredictionModelWeight.prediction_model_name == model.name,
-                        QualityPredictionModelWeight.metric_name == metric.name,
+                existing_weight = (
+                    (
+                        await sess.execute(
+                            select(QualityPredictionModelWeight).where(
+                                QualityPredictionModelWeight.grid_uuid == grid_uuid,
+                                QualityPredictionModelWeight.prediction_model_name == model.name,
+                                QualityPredictionModelWeight.metric_name == metric.name,
+                            )
+                        )
                     )
-                ).first()
+                    .scalars()
+                    .first()
+                )
 
                 if existing_weight is None:
                     weight_entry = QualityPredictionModelWeight(
@@ -65,38 +68,34 @@ def initialise_all_models_for_grid(grid_uuid: str, engine: Engine = None) -> Non
                 else:
                     logger.debug(f"Weight already exists for model '{model.name}' on grid {grid_uuid}")
 
-        sess.commit()
+        await sess.commit()
 
 
-def initialise_prediction_model_for_grid(
-    name: str, weight: float, grid_uuid: str | None = None, engine: Engine = None
+async def initialise_prediction_model_for_grid(
+    name: str, weight: float, grid_uuid: str | None = None, engine: AsyncEngine | None = None
 ) -> None:
-    """
-    Initialise a single prediction model weight for a grid (CLI interface).
-
-    Args:
-        name: Prediction model name
-        weight: Weight value to assign
-        grid_uuid: Grid UUID (if None, uses first available grid)
-        engine: Optional database engine (uses singleton if not provided)
-    """
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
+    async with session_factory() as sess:
         if grid_uuid is None:
-            grid = sess.exec(select(Grid)).first()
+            grid = (await sess.execute(select(Grid))).scalars().first()
             if grid is None:
                 logger.error("No grids found in database")
                 return
             grid_uuid = grid.uuid
 
         sess.add(QualityPredictionModelWeight(grid_uuid=grid_uuid, prediction_model_name=name, weight=weight))
-        sess.commit()
+        await sess.commit()
         logger.info(f"Initialised weight {weight} for model '{name}' on grid {grid_uuid}")
     return None
 
 
+def _typer_entry(name: str, weight: float, grid_uuid: str | None = None) -> None:
+    asyncio.run(initialise_prediction_model_for_grid(name, weight, grid_uuid))
+
+
 def run() -> None:
-    typer.run(initialise_prediction_model_for_grid)
+    typer.run(_typer_entry)
     return None

--- a/src/smartem_backend/cli/random_model_predictions.py
+++ b/src/smartem_backend/cli/random_model_predictions.py
@@ -1,40 +1,50 @@
+import asyncio
 import random
 from typing import Annotated
 
 import typer
-from sqlalchemy.engine import Engine
-from sqlmodel import Session, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from smartem_backend.model.database import FoilHole, Grid, GridSquare, QualityPrediction, QualityPredictionModel
-from smartem_backend.utils import get_db_engine, logger
+from smartem_backend.utils import logger, setup_postgres_async_connection
 
 DEFAULT_PREDICTION_RANGE = (0.0, 1.0)
 
 
-def generate_random_predictions(
+def _make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=engine, class_=AsyncSession, autocommit=False, autoflush=False, expire_on_commit=False
+    )
+
+
+async def generate_random_predictions(
     model_name: str,
     grid_uuid: str | None = None,
     random_range: tuple[float, float] = (0, 1),
     level: Annotated[
         str, typer.Option(help="Magnification level at which to generate predictions. Options are 'hole' or 'square'")
     ] = "hole",
-    engine: Engine = None,
+    engine: AsyncEngine | None = None,
 ) -> None:
     if level not in ("hole", "square"):
         raise ValueError(f"Level must be set to either 'hole' or 'square' not {level}")
 
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
+    async with session_factory() as sess:
         if grid_uuid is None:
-            grid = sess.exec(select(Grid)).first()
+            grid = (await sess.execute(select(Grid))).scalars().first()
             grid_uuid = grid.uuid
         if level == "hole":
-            holes = sess.exec(
-                select(FoilHole, GridSquare)
-                .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
-                .where(GridSquare.grid_uuid == grid_uuid)
+            holes = (
+                await sess.execute(
+                    select(FoilHole, GridSquare)
+                    .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
+                    .where(GridSquare.grid_uuid == grid_uuid)
+                )
             ).all()
             preds = [
                 QualityPrediction(
@@ -45,9 +55,9 @@ def generate_random_predictions(
                 for h in holes
             ]
             sess.add_all(preds)
-            sess.commit()
+            await sess.commit()
         else:
-            squares = sess.exec(select(GridSquare).where(GridSquare.grid_uuid == grid_uuid)).all()
+            squares = (await sess.execute(select(GridSquare).where(GridSquare.grid_uuid == grid_uuid))).scalars().all()
             preds = [
                 QualityPrediction(
                     value=random.uniform(random_range[0], random_range[1]),
@@ -57,51 +67,46 @@ def generate_random_predictions(
                 for s in squares
             ]
             sess.add_all(preds)
-            sess.commit()
+            await sess.commit()
 
     return None
 
 
-def generate_predictions_for_gridsquare(
-    gridsquare_uuid: str, grid_uuid: str | None = None, engine: Engine = None
+async def generate_predictions_for_gridsquare(
+    gridsquare_uuid: str, grid_uuid: str | None = None, engine: AsyncEngine | None = None
 ) -> None:
-    """
-    Generate random predictions for a single gridsquare using all available models.
-
-    Args:
-        gridsquare_uuid: UUID of the gridsquare to generate predictions for
-        grid_uuid: UUID of the parent grid (optional, will be looked up if not provided)
-        engine: Optional database engine (uses singleton if not provided)
-    """
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
-        # Get all available prediction models
-        models = sess.exec(select(QualityPredictionModel)).all()
+    async with session_factory() as sess:
+        models = (await sess.execute(select(QualityPredictionModel))).scalars().all()
 
         if not models:
             logger.warning(f"No prediction models found to generate predictions for gridsquare {gridsquare_uuid}")
             return
 
-        # If grid_uuid not provided, look it up
         if grid_uuid is None:
-            gridsquare = sess.get(GridSquare, gridsquare_uuid)
+            gridsquare = await sess.get(GridSquare, gridsquare_uuid)
             if gridsquare is None:
                 logger.error(f"GridSquare {gridsquare_uuid} not found in database")
                 return
             grid_uuid = gridsquare.grid_uuid
 
-        # Generate predictions for each model
         predictions = []
         for model in models:
-            # Check if prediction already exists for this gridsquare-model combination
-            existing_prediction = sess.exec(
-                select(QualityPrediction).where(
-                    QualityPrediction.gridsquare_uuid == gridsquare_uuid,
-                    QualityPrediction.prediction_model_name == model.name,
+            existing_prediction = (
+                (
+                    await sess.execute(
+                        select(QualityPrediction).where(
+                            QualityPrediction.gridsquare_uuid == gridsquare_uuid,
+                            QualityPrediction.prediction_model_name == model.name,
+                        )
+                    )
                 )
-            ).first()
+                .scalars()
+                .first()
+            )
 
             if existing_prediction is None:
                 prediction = QualityPrediction(
@@ -119,35 +124,26 @@ def generate_predictions_for_gridsquare(
 
         if predictions:
             sess.add_all(predictions)
-            sess.commit()
+            await sess.commit()
             logger.info(f"Generated {len(predictions)} predictions for gridsquare {gridsquare_uuid}")
 
 
-def generate_predictions_for_foilhole(
-    foilhole_uuid: str, gridsquare_uuid: str | None = None, engine: Engine = None
+async def generate_predictions_for_foilhole(
+    foilhole_uuid: str, gridsquare_uuid: str | None = None, engine: AsyncEngine | None = None
 ) -> None:
-    """
-    Generate random predictions for a single foilhole using all available models.
-
-    Args:
-        foilhole_uuid: UUID of the foilhole to generate predictions for
-        gridsquare_uuid: UUID of the parent gridsquare (optional, for validation if provided)
-        engine: Optional database engine (uses singleton if not provided)
-    """
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
-        # Get all available prediction models
-        models = sess.exec(select(QualityPredictionModel)).all()
+    async with session_factory() as sess:
+        models = (await sess.execute(select(QualityPredictionModel))).scalars().all()
 
         if not models:
             logger.warning(f"No prediction models found to generate predictions for foilhole {foilhole_uuid}")
             return
 
-        # Optional validation: if gridsquare_uuid provided, verify the foilhole belongs to it
         if gridsquare_uuid is not None:
-            foilhole = sess.get(FoilHole, foilhole_uuid)
+            foilhole = await sess.get(FoilHole, foilhole_uuid)
             if foilhole is None:
                 logger.error(f"FoilHole {foilhole_uuid} not found in database")
                 return
@@ -157,16 +153,20 @@ def generate_predictions_for_foilhole(
                 )
                 return
 
-        # Generate predictions for each model
         predictions = []
         for model in models:
-            # Check if prediction already exists for this foilhole-model combination
-            existing_prediction = sess.exec(
-                select(QualityPrediction).where(
-                    QualityPrediction.foilhole_uuid == foilhole_uuid,
-                    QualityPrediction.prediction_model_name == model.name,
+            existing_prediction = (
+                (
+                    await sess.execute(
+                        select(QualityPrediction).where(
+                            QualityPrediction.foilhole_uuid == foilhole_uuid,
+                            QualityPrediction.prediction_model_name == model.name,
+                        )
+                    )
                 )
-            ).first()
+                .scalars()
+                .first()
+            )
 
             if existing_prediction is None:
                 prediction = QualityPrediction(
@@ -183,10 +183,21 @@ def generate_predictions_for_foilhole(
 
         if predictions:
             sess.add_all(predictions)
-            sess.commit()
+            await sess.commit()
             logger.info(f"Generated {len(predictions)} predictions for foilhole {foilhole_uuid}")
 
 
+def _typer_entry(
+    model_name: str,
+    grid_uuid: str | None = None,
+    random_range: tuple[float, float] = (0, 1),
+    level: Annotated[
+        str, typer.Option(help="Magnification level at which to generate predictions. Options are 'hole' or 'square'")
+    ] = "hole",
+) -> None:
+    asyncio.run(generate_random_predictions(model_name, grid_uuid, random_range, level))
+
+
 def run() -> None:
-    typer.run(generate_random_predictions)
+    typer.run(_typer_entry)
     return None

--- a/src/smartem_backend/cli/random_prior_updates.py
+++ b/src/smartem_backend/cli/random_prior_updates.py
@@ -1,58 +1,66 @@
+import asyncio
 import random
-import threading
-import time
 
 import typer
-from sqlalchemy.engine import Engine
-from sqlmodel import Session, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlmodel import select
 
 from smartem_backend.model.database import FoilHole, Grid, GridSquare, Micrograph
 from smartem_backend.predictions.update import prior_update
-from smartem_backend.utils import get_db_engine, logger
+from smartem_backend.utils import logger, setup_postgres_async_connection
 
-# Default time ranges for processing steps (in seconds)
 DEFAULT_MOTION_CORRECTION_DELAY = (1.0, 3.0)
 DEFAULT_CTF_DELAY = (2.0, 5.0)
 DEFAULT_PARTICLE_PICKING_DELAY = (3.0, 8.0)
 DEFAULT_PARTICLE_SELECTION_DELAY = (2.0, 6.0)
 
+# Hold strong references to background simulation tasks so they aren't garbage
+# collected mid-flight (asyncio only weakly retains tasks unless something awaits them).
+_background_tasks: set[asyncio.Task] = set()
 
-def perform_random_updates(
+
+def _make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=engine, class_=AsyncSession, autocommit=False, autoflush=False, expire_on_commit=False
+    )
+
+
+async def perform_random_updates(
     grid_uuid: str | None = None,
     random_range: tuple[float, float] = (0, 1),
     metric: str = "motioncorrection",
-    engine: Engine = None,
+    engine: AsyncEngine | None = None,
 ) -> None:
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
-    with Session(engine) as sess:
+    async with session_factory() as sess:
         if grid_uuid is None:
-            grid = sess.exec(select(Grid)).first()
+            grid = (await sess.execute(select(Grid))).scalars().first()
             grid_uuid = grid.uuid
-        mics = sess.exec(
-            select(Micrograph, FoilHole, GridSquare)
-            .where(Micrograph.foilhole_uuid == FoilHole.uuid)
-            .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
-            .where(GridSquare.grid_uuid == grid_uuid)
+        mics = (
+            await sess.execute(
+                select(Micrograph, FoilHole, GridSquare)
+                .where(Micrograph.foilhole_uuid == FoilHole.uuid)
+                .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
+                .where(GridSquare.grid_uuid == grid_uuid)
+            )
         ).all()
         for m in mics:
-            prior_update(random.uniform(random_range[0], random_range[1]) < 0.5, m[0].uuid, sess, metric=metric)
+            quality = float(random.uniform(random_range[0], random_range[1]) < 0.5)
+            await prior_update(quality, m[0].uuid, metric, sess)
     return None
 
 
-def simulate_processing_pipeline(micrograph_uuid: str, engine: Engine = None) -> None:
-    """
-    Simulate the data processing pipeline for a micrograph with random delays.
+async def simulate_processing_pipeline(micrograph_uuid: str, engine: AsyncEngine | None = None) -> None:
+    """Simulate the data processing pipeline for a micrograph with random delays.
 
-    Pipeline: motion correction → ctf → particle picking → particle selection
-
-    Args:
-        micrograph_uuid: UUID of the micrograph to process
-        engine: Optional database engine (uses singleton if not provided)
+    Pipeline: motion correction -> ctf -> particle picking -> particle selection.
     """
     if engine is None:
-        engine = get_db_engine()
+        engine = setup_postgres_async_connection()
+    session_factory = _make_session_factory(engine)
 
     processing_steps = [
         ("motion_correction", DEFAULT_MOTION_CORRECTION_DELAY),
@@ -64,45 +72,41 @@ def simulate_processing_pipeline(micrograph_uuid: str, engine: Engine = None) ->
     logger.info(f"Starting processing pipeline simulation for micrograph {micrograph_uuid}")
 
     for step_name, delay_range in processing_steps:
-        # Random delay for this processing step
         delay = random.uniform(delay_range[0], delay_range[1])
         logger.debug(f"Simulating {step_name} for micrograph {micrograph_uuid}, delay: {delay:.2f}s")
-        time.sleep(delay)
+        await asyncio.sleep(delay)
 
-        # Perform random weight update for this step - reuse the same engine
         try:
-            with Session(engine) as sess:
-                # Generate random quality result (True/False)
-                quality_result = random.choice([True, False])
-                prior_update(quality=quality_result, micrograph_uuid=micrograph_uuid, session=sess, metric=step_name)
+            async with session_factory() as sess:
+                quality_result = float(random.choice([True, False]))
+                await prior_update(quality_result, micrograph_uuid, step_name, sess)
                 logger.info(f"Completed {step_name} for micrograph {micrograph_uuid}, quality: {quality_result}")
         except Exception as e:
             logger.error(f"Error in {step_name} for micrograph {micrograph_uuid}: {e}")
-            # Continue with next step even if one fails
 
     logger.info(f"Completed processing pipeline simulation for micrograph {micrograph_uuid}")
 
 
-def simulate_processing_pipeline_async(micrograph_uuid: str, engine: Engine = None) -> None:
+async def simulate_processing_pipeline_async(micrograph_uuid: str, engine: AsyncEngine | None = None) -> None:
+    """Spawn the processing pipeline simulation as a background asyncio task.
+
+    Returns once the task is scheduled; the simulation runs concurrently on the
+    consumer's event loop and does not block the caller.
     """
-    Start the processing pipeline simulation in a background thread.
-
-    Args:
-        micrograph_uuid: UUID of the micrograph to process
-        engine: Optional database engine (uses singleton if not provided)
-    """
-    if engine is None:
-        engine = get_db_engine()
-
-    def run_simulation():
-        simulate_processing_pipeline(micrograph_uuid, engine)
-
-    # Start simulation in background thread so it doesn't block the consumer
-    thread = threading.Thread(target=run_simulation, daemon=True)
-    thread.start()
+    task = asyncio.create_task(simulate_processing_pipeline(micrograph_uuid, engine))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
     logger.debug(f"Started background processing simulation for micrograph {micrograph_uuid}")
 
 
+def _typer_entry(
+    grid_uuid: str | None = None,
+    random_range: tuple[float, float] = (0, 1),
+    metric: str = "motioncorrection",
+) -> None:
+    asyncio.run(perform_random_updates(grid_uuid, random_range, metric))
+
+
 def run() -> None:
-    typer.run(perform_random_updates)
+    typer.run(_typer_entry)
     return None

--- a/src/smartem_backend/consumer.py
+++ b/src/smartem_backend/consumer.py
@@ -16,10 +16,8 @@ import scipy.stats
 from aio_pika.abc import AbstractIncomingMessage
 from dotenv import load_dotenv
 from pydantic import ValidationError
-from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
-from sqlmodel import Session, select
-from starlette.concurrency import run_in_threadpool
+from sqlmodel import select
 
 from smartem_backend import mq_publisher as mq_publisher_module
 from smartem_backend.cli.initialise_prediction_model_weights import initialise_all_models_for_grid
@@ -90,7 +88,7 @@ from smartem_backend.predictions.acquisition import ordered_holes
 from smartem_backend.predictions.update import overall_predictions_update, prior_update
 from smartem_backend.rmq import AioPikaConsumer, AioPikaPublisher, decode_event_body
 from smartem_backend.rmq.config import load_rmq_connection_url, load_rmq_topology
-from smartem_backend.utils import get_db_engine, load_conf, setup_logger, setup_postgres_async_connection
+from smartem_backend.utils import load_conf, setup_logger, setup_postgres_async_connection
 
 load_dotenv(override=False)  # Don't override existing env vars as these might be coming from k8s
 conf = load_conf()
@@ -99,17 +97,14 @@ conf = load_conf()
 log_manager = LogManager.get_instance("smartem_backend")
 logger = log_manager.configure(LogConfig(level=logging.ERROR, console=True))
 
-db_engine: Engine
 async_db_engine: AsyncEngine
 SessionLocal: async_sessionmaker[AsyncSession]
 if os.getenv("SKIP_DB_INIT", "false").lower() != "true":
-    db_engine = get_db_engine()
     async_db_engine = setup_postgres_async_connection()
     SessionLocal = async_sessionmaker(
         bind=async_db_engine, class_=AsyncSession, autocommit=False, autoflush=False, expire_on_commit=False
     )
 else:
-    db_engine = None  # type: ignore[assignment]
     async_db_engine = None  # type: ignore[assignment]
     SessionLocal = None  # type: ignore[assignment]
 
@@ -180,15 +175,10 @@ async def handle_grid_created(event_data: dict[str, Any]) -> None:
     try:
         event = GridCreatedEvent(**event_data)
         logger.info(f"Grid created event: {event.model_dump()}")
-
-        def _initialise():
-            initialise_all_models_for_grid(event.uuid, engine=db_engine)
-
         try:
-            await run_in_threadpool(_initialise)
+            await initialise_all_models_for_grid(event.uuid)
             logger.info(f"Successfully initialised prediction model weights for grid {event.uuid}")
         except Exception as weight_init_error:
-            # Don't fail the entire event processing if weight initialisation fails.
             logger.error(f"Failed to initialise prediction model weights for grid {event.uuid}: {weight_init_error}")
     except ValidationError as e:
         logger.error(f"Validation error processing grid created event: {e}")
@@ -240,12 +230,8 @@ async def handle_gridsquare_created(event_data: dict[str, Any]) -> None:
     try:
         event = GridSquareCreatedEvent(**event_data)
         logger.info(f"GridSquare created event: {event.model_dump()}")
-
-        def _generate():
-            generate_predictions_for_gridsquare(event.uuid, event.grid_uuid, engine=db_engine)
-
         try:
-            await run_in_threadpool(_generate)
+            await generate_predictions_for_gridsquare(event.uuid, event.grid_uuid)
             logger.info(f"Successfully generated predictions for gridsquare {event.uuid}")
         except Exception as prediction_error:
             logger.error(f"Failed to generate predictions for gridsquare {event.uuid}: {prediction_error}")
@@ -309,12 +295,8 @@ async def handle_foilhole_created(event_data: dict[str, Any]) -> None:
     try:
         event = FoilHoleCreatedEvent(**event_data)
         logger.info(f"FoilHole created event: {event.model_dump()}")
-
-        def _generate():
-            generate_predictions_for_foilhole(event.uuid, event.gridsquare_uuid, engine=db_engine)
-
         try:
-            await run_in_threadpool(_generate)
+            await generate_predictions_for_foilhole(event.uuid, event.gridsquare_uuid)
             logger.info(f"Successfully generated predictions for foilhole {event.uuid}")
         except Exception as prediction_error:
             logger.error(f"Failed to generate predictions for foilhole {event.uuid}: {prediction_error}")
@@ -348,14 +330,8 @@ async def handle_micrograph_created(event_data: dict[str, Any]) -> None:
     try:
         event = MicrographCreatedEvent(**event_data)
         logger.info(f"Micrograph created event: {event.model_dump()}")
-
-        # simulate_processing_pipeline_async spawns its own background worker;
-        # run it in the threadpool so any blocking setup doesn't stall the loop.
-        def _simulate():
-            simulate_processing_pipeline_async(event.uuid, engine=db_engine)
-
         try:
-            await run_in_threadpool(_simulate)
+            await simulate_processing_pipeline_async(event.uuid)
             logger.info(f"Started processing pipeline simulation for micrograph {event.uuid}")
         except Exception as simulation_error:
             logger.error(f"Failed to start processing simulation for micrograph {event.uuid}: {simulation_error}")
@@ -385,28 +361,33 @@ async def handle_micrograph_deleted(event_data: dict[str, Any]) -> None:
         logger.error(f"Error processing micrograph deleted event: {e}")
 
 
-def _check_against_statistics(
+async def _check_against_statistics(
     metric_name: str,
     micrograph_uuid: str,
     comparison_value: float,
     larger_better: bool = False,
 ) -> float:
-    with Session(db_engine) as session:
-        grid_uuid = (
-            session.exec(
+    async with SessionLocal() as session:
+        grid_row = (
+            await session.execute(
                 select(GridSquare, FoilHole, Micrograph)
                 .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
                 .where(FoilHole.uuid == Micrograph.foilhole_uuid)
                 .where(Micrograph.uuid == micrograph_uuid)
             )
-            .one()[0]
-            .grid_uuid
+        ).one()
+        grid_uuid = grid_row[0].grid_uuid
+        metric_stats = (
+            (
+                await session.execute(
+                    select(QualityMetricStatistics)
+                    .where(QualityMetricStatistics.grid_uuid == grid_uuid)
+                    .where(QualityMetricStatistics.name == metric_name)
+                )
+            )
+            .scalars()
+            .all()
         )
-        metric_stats = session.exec(
-            select(QualityMetricStatistics)
-            .where(QualityMetricStatistics.grid_uuid == grid_uuid)
-            .where(QualityMetricStatistics.name == metric_name)
-        ).all()
     if not metric_stats:
         return 1
     elif metric_stats[0].count < 2:
@@ -426,47 +407,47 @@ def _check_against_statistics(
 async def handle_motion_correction_complete(event_data: dict[str, Any]) -> None:
     try:
         event = MotionCorrectionCompleteBody(**event_data)
-
-        def _db_work() -> float:
-            quality = _check_against_statistics("motioncorrection", event.micrograph_uuid, event.total_motion)
-            with Session(db_engine) as session:
-                grid_uuid = (
-                    session.exec(
-                        select(GridSquare, FoilHole, Micrograph)
-                        .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-                        .where(FoilHole.uuid == Micrograph.foilhole_uuid)
-                        .where(Micrograph.uuid == event.micrograph_uuid)
-                    )
-                    .one()[0]
-                    .grid_uuid
+        quality = await _check_against_statistics("motioncorrection", event.micrograph_uuid, event.total_motion)
+        async with SessionLocal() as session:
+            grid_row = (
+                await session.execute(
+                    select(GridSquare, FoilHole, Micrograph)
+                    .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+                    .where(FoilHole.uuid == Micrograph.foilhole_uuid)
+                    .where(Micrograph.uuid == event.micrograph_uuid)
                 )
-                metric_stats = session.exec(
-                    select(QualityMetricStatistics)
-                    .where(QualityMetricStatistics.grid_uuid == grid_uuid)
-                    .where(QualityMetricStatistics.name == "motioncorrection")
-                ).all()
-                if not metric_stats:
-                    updated_metric_stats = QualityMetricStatistics(
-                        grid_uuid=grid_uuid,
-                        name="motioncorrection",
-                        count=1,
-                        value_sum=event.total_motion,
-                        squared_value_sum=0,
+            ).one()
+            grid_uuid = grid_row[0].grid_uuid
+            metric_stats = (
+                (
+                    await session.execute(
+                        select(QualityMetricStatistics)
+                        .where(QualityMetricStatistics.grid_uuid == grid_uuid)
+                        .where(QualityMetricStatistics.name == "motioncorrection")
                     )
-                else:
-                    updated_metric_stats = metric_stats[0]
-                    old_diff = event.total_motion - (updated_metric_stats.value_sum / updated_metric_stats.count)
-                    updated_metric_stats.count += 1
-                    updated_metric_stats.value_sum += event.total_motion
-                    updated_metric_stats.squared_value_sum += old_diff * (
-                        event.total_motion - (updated_metric_stats.value_sum / updated_metric_stats.count)
-                    )
-                session.add(updated_metric_stats)
-                session.commit()
-                prior_update(quality, event.micrograph_uuid, "motioncorrection", session)
-            return quality
-
-        quality = await run_in_threadpool(_db_work)
+                )
+                .scalars()
+                .all()
+            )
+            if not metric_stats:
+                updated_metric_stats = QualityMetricStatistics(
+                    grid_uuid=grid_uuid,
+                    name="motioncorrection",
+                    count=1,
+                    value_sum=event.total_motion,
+                    squared_value_sum=0,
+                )
+            else:
+                updated_metric_stats = metric_stats[0]
+                old_diff = event.total_motion - (updated_metric_stats.value_sum / updated_metric_stats.count)
+                updated_metric_stats.count += 1
+                updated_metric_stats.value_sum += event.total_motion
+                updated_metric_stats.squared_value_sum += old_diff * (
+                    event.total_motion - (updated_metric_stats.value_sum / updated_metric_stats.count)
+                )
+            session.add(updated_metric_stats)
+            await session.commit()
+            await prior_update(quality, event.micrograph_uuid, "motioncorrection", session)
         await publish_motion_correction_registered(
             event.micrograph_uuid, quality >= 0.5, metric_name="motioncorrection"
         )
@@ -479,52 +460,51 @@ async def handle_motion_correction_complete(event_data: dict[str, Any]) -> None:
 async def handle_ctf_estimation_complete(event_data: dict[str, Any]) -> None:
     try:
         event = CtfCompleteBody(**event_data)
-
-        def _db_work() -> float:
-            quality = _check_against_statistics(
-                "ctfmaxresolution", event.micrograph_uuid, event.ctf_max_resolution_estimate
-            )
-            with Session(db_engine) as session:
-                grid_uuid = (
-                    session.exec(
-                        select(GridSquare, FoilHole, Micrograph)
-                        .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-                        .where(FoilHole.uuid == Micrograph.foilhole_uuid)
-                        .where(Micrograph.uuid == event.micrograph_uuid)
-                    )
-                    .one()[0]
-                    .grid_uuid
+        quality = await _check_against_statistics(
+            "ctfmaxresolution", event.micrograph_uuid, event.ctf_max_resolution_estimate
+        )
+        async with SessionLocal() as session:
+            grid_row = (
+                await session.execute(
+                    select(GridSquare, FoilHole, Micrograph)
+                    .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+                    .where(FoilHole.uuid == Micrograph.foilhole_uuid)
+                    .where(Micrograph.uuid == event.micrograph_uuid)
                 )
-                metric_stats = session.exec(
-                    select(QualityMetricStatistics)
-                    .where(QualityMetricStatistics.grid_uuid == grid_uuid)
-                    .where(QualityMetricStatistics.name == "ctfmaxresolution")
-                ).all()
-                if not metric_stats:
-                    updated_metric_stats = QualityMetricStatistics(
-                        grid_uuid=grid_uuid,
-                        name="ctfmaxresolution",
-                        count=1,
-                        value_sum=event.ctf_max_resolution_estimate,
-                        squared_value_sum=0,
+            ).one()
+            grid_uuid = grid_row[0].grid_uuid
+            metric_stats = (
+                (
+                    await session.execute(
+                        select(QualityMetricStatistics)
+                        .where(QualityMetricStatistics.grid_uuid == grid_uuid)
+                        .where(QualityMetricStatistics.name == "ctfmaxresolution")
                     )
-                else:
-                    updated_metric_stats = metric_stats[0]
-                    old_diff = event.ctf_max_resolution_estimate - (
-                        updated_metric_stats.value_sum / updated_metric_stats.count
-                    )
-                    updated_metric_stats.count += 1
-                    updated_metric_stats.value_sum += event.ctf_max_resolution_estimate
-                    updated_metric_stats.squared_value_sum += old_diff * (
-                        event.ctf_max_resolution_estimate
-                        - (updated_metric_stats.value_sum / updated_metric_stats.count)
-                    )
-                session.add(updated_metric_stats)
-                session.commit()
-                prior_update(quality, event.micrograph_uuid, "ctfmaxresolution", session)
-            return quality
-
-        quality = await run_in_threadpool(_db_work)
+                )
+                .scalars()
+                .all()
+            )
+            if not metric_stats:
+                updated_metric_stats = QualityMetricStatistics(
+                    grid_uuid=grid_uuid,
+                    name="ctfmaxresolution",
+                    count=1,
+                    value_sum=event.ctf_max_resolution_estimate,
+                    squared_value_sum=0,
+                )
+            else:
+                updated_metric_stats = metric_stats[0]
+                old_diff = event.ctf_max_resolution_estimate - (
+                    updated_metric_stats.value_sum / updated_metric_stats.count
+                )
+                updated_metric_stats.count += 1
+                updated_metric_stats.value_sum += event.ctf_max_resolution_estimate
+                updated_metric_stats.squared_value_sum += old_diff * (
+                    event.ctf_max_resolution_estimate - (updated_metric_stats.value_sum / updated_metric_stats.count)
+                )
+            session.add(updated_metric_stats)
+            await session.commit()
+            await prior_update(quality, event.micrograph_uuid, "ctfmaxresolution", session)
         await publish_ctf_estimation_registered(event.micrograph_uuid, quality >= 0.5, metric_name="ctfmaxresolution")
     except ValidationError as e:
         logger.error(f"Validation error processing ctf event: {e}")
@@ -535,51 +515,51 @@ async def handle_ctf_estimation_complete(event_data: dict[str, Any]) -> None:
 async def handle_particle_picking_complete(event_data: dict[str, Any]) -> None:
     try:
         event = ParticlePickingCompleteBody(**event_data)
-
-        def _db_work() -> float:
-            quality = _check_against_statistics(
-                "numparticles", event.micrograph_uuid, event.number_of_particles_picked, larger_better=True
-            )
-            with Session(db_engine) as session:
-                grid_uuid = (
-                    session.exec(
-                        select(GridSquare, FoilHole, Micrograph)
-                        .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-                        .where(FoilHole.uuid == Micrograph.foilhole_uuid)
-                        .where(Micrograph.uuid == event.micrograph_uuid)
-                    )
-                    .one()[0]
-                    .grid_uuid
+        quality = await _check_against_statistics(
+            "numparticles", event.micrograph_uuid, event.number_of_particles_picked, larger_better=True
+        )
+        async with SessionLocal() as session:
+            grid_row = (
+                await session.execute(
+                    select(GridSquare, FoilHole, Micrograph)
+                    .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+                    .where(FoilHole.uuid == Micrograph.foilhole_uuid)
+                    .where(Micrograph.uuid == event.micrograph_uuid)
                 )
-                metric_stats = session.exec(
-                    select(QualityMetricStatistics)
-                    .where(QualityMetricStatistics.grid_uuid == grid_uuid)
-                    .where(QualityMetricStatistics.name == "numparticles")
-                ).all()
-                if not metric_stats:
-                    updated_metric_stats = QualityMetricStatistics(
-                        grid_uuid=grid_uuid,
-                        name="numparticles",
-                        count=1,
-                        value_sum=event.number_of_particles_picked,
-                        squared_value_sum=0,
+            ).one()
+            grid_uuid = grid_row[0].grid_uuid
+            metric_stats = (
+                (
+                    await session.execute(
+                        select(QualityMetricStatistics)
+                        .where(QualityMetricStatistics.grid_uuid == grid_uuid)
+                        .where(QualityMetricStatistics.name == "numparticles")
                     )
-                else:
-                    updated_metric_stats = metric_stats[0]
-                    old_diff = event.number_of_particles_picked - (
-                        updated_metric_stats.value_sum / updated_metric_stats.count
-                    )
-                    updated_metric_stats.count += 1
-                    updated_metric_stats.value_sum += event.number_of_particles_picked
-                    updated_metric_stats.squared_value_sum += old_diff * (
-                        event.number_of_particles_picked - (updated_metric_stats.value_sum / updated_metric_stats.count)
-                    )
-                session.add(updated_metric_stats)
-                session.commit()
-                prior_update(quality, event.micrograph_uuid, "numparticles", session)
-            return quality
-
-        quality = await run_in_threadpool(_db_work)
+                )
+                .scalars()
+                .all()
+            )
+            if not metric_stats:
+                updated_metric_stats = QualityMetricStatistics(
+                    grid_uuid=grid_uuid,
+                    name="numparticles",
+                    count=1,
+                    value_sum=event.number_of_particles_picked,
+                    squared_value_sum=0,
+                )
+            else:
+                updated_metric_stats = metric_stats[0]
+                old_diff = event.number_of_particles_picked - (
+                    updated_metric_stats.value_sum / updated_metric_stats.count
+                )
+                updated_metric_stats.count += 1
+                updated_metric_stats.value_sum += event.number_of_particles_picked
+                updated_metric_stats.squared_value_sum += old_diff * (
+                    event.number_of_particles_picked - (updated_metric_stats.value_sum / updated_metric_stats.count)
+                )
+            session.add(updated_metric_stats)
+            await session.commit()
+            await prior_update(quality, event.micrograph_uuid, "numparticles", session)
         await publish_particle_picking_registered(event.micrograph_uuid, quality >= 0.5, metric_name="numparticles")
     except ValidationError as e:
         logger.error(f"Validation error processing particle picking event: {e}")
@@ -841,13 +821,9 @@ async def handle_foilhole_group_model_prediction(event_data: dict[str, Any]) -> 
 async def handle_refresh_predictions(event_data: dict[str, Any]) -> None:
     try:
         event = RefreshPredictionsEvent(**event_data)
-
-        def _db_work():
-            with Session(db_engine) as session:
-                overall_predictions_update(event.grid_uuid, session)
-                ordered_holes(event.grid_uuid, session)
-
-        await run_in_threadpool(_db_work)
+        async with SessionLocal() as session:
+            await overall_predictions_update(event.grid_uuid, session)
+            await ordered_holes(event.grid_uuid, session)
     except ValidationError as e:
         logger.error(f"Validation error processing refresh predictions event: {e}")
     except Exception as e:

--- a/src/smartem_backend/predictions/acquisition.py
+++ b/src/smartem_backend/predictions/acquisition.py
@@ -1,14 +1,15 @@
 import numpy as np
 from sqlalchemy.dialects.postgresql import array_agg
-from sqlmodel import Session, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
 from smartem_backend.model.database import (
     OverallQualityPrediction,
 )
 
 
-def get_all_scores_for_grid(grid_uuid: str, session: Session) -> dict[str, tuple[str, float]]:
-    overall_predictions = session.exec(
+async def get_all_scores_for_grid(grid_uuid: str, session: AsyncSession) -> dict[str, tuple[str, float]]:
+    result = await session.execute(
         select(
             OverallQualityPrediction.gridsquare_uuid,
             array_agg(OverallQualityPrediction.foilhole_uuid),
@@ -16,7 +17,8 @@ def get_all_scores_for_grid(grid_uuid: str, session: Session) -> dict[str, tuple
         )
         .where(OverallQualityPrediction.grid_uuid == grid_uuid)
         .group_by(OverallQualityPrediction.gridsquare_uuid)
-    ).all()
+    )
+    overall_predictions = result.all()
     return {
         el[0]: sorted(zip(el[1], el[2], strict=False), key=lambda x: x[1], reverse=True) for el in overall_predictions
     }
@@ -137,12 +139,13 @@ def _ordered_holes(square_scores_and_uuids: dict[str, tuple[str, float]]) -> lis
     return hole_order
 
 
-def ordered_holes(grid_uuid: str, session: Session) -> list[str]:
-    square_scores_and_uuids = get_all_scores_for_grid(grid_uuid, session)
+async def ordered_holes(grid_uuid: str, session: AsyncSession) -> list[str]:
+    square_scores_and_uuids = await get_all_scores_for_grid(grid_uuid, session)
     holes = _ordered_holes(square_scores_and_uuids)
-    overall_predictions = session.exec(
+    result = await session.execute(
         select(OverallQualityPrediction).where(OverallQualityPrediction.grid_uuid == grid_uuid)
-    ).all()
+    )
+    overall_predictions = result.scalars().all()
     overall_prediction_map = {p.foilhole_uuid: p for p in overall_predictions}
     updated_predictions = []
     for i, h in enumerate(holes):
@@ -150,5 +153,5 @@ def ordered_holes(grid_uuid: str, session: Session) -> list[str]:
         pred.suggested_acquisition_index = i + 1
         updated_predictions.append(pred)
     session.add_all(updated_predictions)
-    session.commit()
+    await session.commit()
     return holes

--- a/src/smartem_backend/predictions/update.py
+++ b/src/smartem_backend/predictions/update.py
@@ -2,8 +2,9 @@ from datetime import datetime, timedelta
 
 import numpy as np
 from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
-from sqlmodel import Session, and_, or_, select
+from sqlmodel import and_, or_, select
 
 from smartem_backend.model.database import (
     CurrentQualityGroupPrediction,
@@ -22,73 +23,97 @@ from smartem_backend.model.database import (
 from smartem_common.entity_status import ModelLevel
 
 
-def prior_update(
+async def prior_update(
     quality: float,
     micrograph_uuid: str,
     metric: str,
-    session: Session,
+    session: AsyncSession,
 ) -> None:
     # get the grid uuid from the micrograph
     # this should only ever produce a single response
-    hierarchy_response = session.exec(
-        select(Micrograph, FoilHole, GridSquare)
-        .where(Micrograph.uuid == micrograph_uuid)
-        .where(FoilHole.uuid == Micrograph.foilhole_uuid)
-        .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
+    hierarchy_response = (
+        await session.execute(
+            select(Micrograph, FoilHole, GridSquare)
+            .where(Micrograph.uuid == micrograph_uuid)
+            .where(FoilHole.uuid == Micrograph.foilhole_uuid)
+            .where(FoilHole.gridsquare_uuid == GridSquare.uuid)
+        )
     ).one()
     grid_uuid = hierarchy_response[2].grid_uuid
     square_uuid = hierarchy_response[2].uuid
     hole_uuid = hierarchy_response[1].uuid
 
-    model_names = [(n.name, n.level) for n in session.exec(select(QualityPredictionModel)).all()]
+    model_rows = (await session.execute(select(QualityPredictionModel))).scalars().all()
+    model_names = [(n.name, n.level) for n in model_rows]
 
     # main prior update logic
     posterior = 0
     delta_missing = 1
     updates = []
     for m, model_level in model_names:
-        weight_row = session.exec(
-            select(CurrentQualityPredictionModelWeight)
-            .where(CurrentQualityPredictionModelWeight.grid_uuid == grid_uuid)
-            .where(CurrentQualityPredictionModelWeight.prediction_model_name == m)
-            .where(CurrentQualityPredictionModelWeight.metric_name == metric)
-        ).one()
+        weight_row = (
+            (
+                await session.execute(
+                    select(CurrentQualityPredictionModelWeight)
+                    .where(CurrentQualityPredictionModelWeight.grid_uuid == grid_uuid)
+                    .where(CurrentQualityPredictionModelWeight.prediction_model_name == m)
+                    .where(CurrentQualityPredictionModelWeight.metric_name == metric)
+                )
+            )
+            .scalars()
+            .one()
+        )
 
         if model_level == ModelLevel.FOILHOLEGROUP:
             # predictions are stored once per group; look up via group membership
-            pred_value = session.exec(
-                select(CurrentQualityGroupPrediction.value)
-                .where(CurrentQualityGroupPrediction.group_uuid == FoilHoleGroupMembership.group_uuid)
-                .where(FoilHoleGroupMembership.foilhole_uuid == hole_uuid)
-                .where(CurrentQualityGroupPrediction.prediction_model_name == m)
-                .where(
-                    or_(
-                        CurrentQualityGroupPrediction.metric_name == metric,
-                        CurrentQualityGroupPrediction.metric_name == None,  # noqa: E711
+            pred_value = (
+                (
+                    await session.execute(
+                        select(CurrentQualityGroupPrediction.value)
+                        .where(CurrentQualityGroupPrediction.group_uuid == FoilHoleGroupMembership.group_uuid)
+                        .where(FoilHoleGroupMembership.foilhole_uuid == hole_uuid)
+                        .where(CurrentQualityGroupPrediction.prediction_model_name == m)
+                        .where(
+                            or_(
+                                CurrentQualityGroupPrediction.metric_name == metric,
+                                CurrentQualityGroupPrediction.metric_name == None,  # noqa: E711
+                            )
+                        )
                     )
                 )
-            ).first()
+                .scalars()
+                .first()
+            )
         else:
             # FOILHOLE and GRIDSQUARE predictions stored in CurrentQualityPrediction
-            pred_row = session.exec(
-                select(CurrentQualityPrediction)
-                .where(
-                    or_(
-                        and_(
-                            CurrentQualityPrediction.foilhole_uuid == hole_uuid,
-                            CurrentQualityPrediction.gridsquare_uuid == square_uuid,
-                        ),
-                        and_(
-                            CurrentQualityPrediction.foilhole_uuid == None,  # noqa: E711
-                            CurrentQualityPrediction.gridsquare_uuid == square_uuid,
-                        ),
+            pred_row = (
+                (
+                    await session.execute(
+                        select(CurrentQualityPrediction)
+                        .where(
+                            or_(
+                                and_(
+                                    CurrentQualityPrediction.foilhole_uuid == hole_uuid,
+                                    CurrentQualityPrediction.gridsquare_uuid == square_uuid,
+                                ),
+                                and_(
+                                    CurrentQualityPrediction.foilhole_uuid == None,  # noqa: E711
+                                    CurrentQualityPrediction.gridsquare_uuid == square_uuid,
+                                ),
+                            )
+                        )
+                        .where(CurrentQualityPrediction.prediction_model_name == m)
+                        .where(
+                            or_(
+                                CurrentQualityPrediction.metric_name == metric,
+                                CurrentQualityPrediction.metric_name == None,  # noqa: E711
+                            )
+                        )
                     )
                 )
-                .where(CurrentQualityPrediction.prediction_model_name == m)
-                .where(
-                    or_(CurrentQualityPrediction.metric_name == metric, CurrentQualityPrediction.metric_name == None)  # noqa: E711
-                )
-            ).first()
+                .scalars()
+                .first()
+            )
             pred_value = pred_row.value if pred_row is not None else None
 
         if pred_value is None:
@@ -116,47 +141,57 @@ def prior_update(
     for update in updates:
         update.weight = delta_missing * update.weight / posterior
         session.add(update)
-    session.commit()
+    await session.commit()
     return None
 
 
-def overall_predictions_update(grid_uuid: str, session: Session) -> None:
+async def overall_predictions_update(grid_uuid: str, session: AsyncSession) -> None:
     # check grid to see if it has been long enough to refresh predictions
-    grid = session.exec(select(Grid).where(Grid.uuid == grid_uuid)).one()
+    grid = (await session.execute(select(Grid).where(Grid.uuid == grid_uuid))).scalars().one()
     if grid.prediction_updated_time > datetime.now() - timedelta(seconds=60):
         return None
 
     # seems easier to just collect the model name for future use here
-    model_names = [(n.name, n.level) for n in session.exec(select(QualityPredictionModel)).all()]
+    model_rows = (await session.execute(select(QualityPredictionModel))).scalars().all()
+    model_names = [(n.name, n.level) for n in model_rows]
     # also get all quality metric names
-    metric_names = [m.name for m in session.exec(select(QualityMetric)).all()]
-    weights = {
-        (w.metric_name, w.prediction_model_name): w.weight
-        for w in session.exec(
-            select(CurrentQualityPredictionModelWeight).where(
-                CurrentQualityPredictionModelWeight.grid_uuid == grid_uuid
+    metric_rows = (await session.execute(select(QualityMetric))).scalars().all()
+    metric_names = [m.name for m in metric_rows]
+    weight_rows = (
+        (
+            await session.execute(
+                select(CurrentQualityPredictionModelWeight).where(
+                    CurrentQualityPredictionModelWeight.grid_uuid == grid_uuid
+                )
             )
-        ).all()
-    }
+        )
+        .scalars()
+        .all()
+    )
+    weights = {(w.metric_name, w.prediction_model_name): w.weight for w in weight_rows}
 
-    grid_square_counts = session.exec(
-        select(GridSquare.uuid, func.count(FoilHole.uuid))
-        .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-        .where(FoilHole.x_location != None)  # noqa: E711
-        .where(GridSquare.grid_uuid == grid_uuid)
-        .order_by(GridSquare.uuid)
-        .group_by(GridSquare.uuid)
+    grid_square_counts = (
+        await session.execute(
+            select(GridSquare.uuid, func.count(FoilHole.uuid))
+            .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+            .where(FoilHole.x_location != None)  # noqa: E711
+            .where(GridSquare.grid_uuid == grid_uuid)
+            .order_by(GridSquare.uuid)
+            .group_by(GridSquare.uuid)
+        )
     ).all()
     num_foil_holes = np.sum([gc[1] for gc in grid_square_counts])
     value_matrix = np.zeros((len(metric_names), len(model_names), num_foil_holes))
 
     # Ordered list of (gridsquare_uuid, foilhole_uuid) matching the value_matrix column order
-    ordered_foilhole_ids = session.exec(
-        select(GridSquare.uuid, FoilHole.uuid)
-        .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-        .where(FoilHole.x_location != None)  # noqa: E711
-        .where(GridSquare.grid_uuid == grid_uuid)
-        .order_by(GridSquare.uuid, FoilHole.uuid)
+    ordered_foilhole_ids = (
+        await session.execute(
+            select(GridSquare.uuid, FoilHole.uuid)
+            .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+            .where(FoilHole.x_location != None)  # noqa: E711
+            .where(GridSquare.grid_uuid == grid_uuid)
+            .order_by(GridSquare.uuid, FoilHole.uuid)
+        )
     ).all()
 
     for imet, metric in enumerate(metric_names):
@@ -172,20 +207,30 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
                     .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
                     .where(CurrentQualityPrediction.prediction_model_name == model)
                 )
-                if (
-                    session.exec(
-                        select(func.count(CurrentQualityPrediction.id))
-                        .where(metric_filter)
-                        .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
-                        .where(CurrentQualityPrediction.prediction_model_name == model)
-                    ).one()
-                    == num_foil_holes
-                ):
-                    preds = session.exec(
-                        pred_query.order_by(
-                            CurrentQualityPrediction.gridsquare_uuid, CurrentQualityPrediction.foilhole_uuid
+                count = (
+                    (
+                        await session.execute(
+                            select(func.count(CurrentQualityPrediction.id))
+                            .where(metric_filter)
+                            .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
+                            .where(CurrentQualityPrediction.prediction_model_name == model)
                         )
-                    ).all()
+                    )
+                    .scalars()
+                    .one()
+                )
+                if count == num_foil_holes:
+                    preds = (
+                        (
+                            await session.execute(
+                                pred_query.order_by(
+                                    CurrentQualityPrediction.gridsquare_uuid, CurrentQualityPrediction.foilhole_uuid
+                                )
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
                 else:
                     pred_alias = aliased(CurrentQualityPrediction, pred_query.subquery())
                     gridsquare_subquery = (
@@ -202,7 +247,7 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
                         .outerjoin(pred_alias, gridsquare_alias.uuid == pred_alias.foilhole_uuid)
                         .order_by(gridsquare_alias.gridsquare_uuid, gridsquare_alias.uuid)
                     )
-                    preds = session.exec(preds_query).all()
+                    preds = (await session.execute(preds_query)).scalars().all()
                 value_matrix[imet, imod] = np.array(
                     [
                         weights[(metric, model)] * p.value if p is not None else weights[(metric, model)] * 0.5
@@ -217,14 +262,25 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
                     .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
                     .where(CurrentQualityPrediction.prediction_model_name == model)
                 )
-                if session.exec(
-                    select(func.count(CurrentQualityPrediction.id))
-                    .where(metric_filter)
-                    .where(CurrentQualityPrediction.gridsquare_uuid.in_([gc[0] for gc in grid_square_counts]))
-                    .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
-                    .where(CurrentQualityPrediction.prediction_model_name == model)
-                ).one() == len(grid_square_counts):
-                    preds = session.exec(pred_query.order_by(CurrentQualityPrediction.gridsquare_uuid)).all()
+                count = (
+                    (
+                        await session.execute(
+                            select(func.count(CurrentQualityPrediction.id))
+                            .where(metric_filter)
+                            .where(CurrentQualityPrediction.gridsquare_uuid.in_([gc[0] for gc in grid_square_counts]))
+                            .where(CurrentQualityPrediction.grid_uuid == grid_uuid)
+                            .where(CurrentQualityPrediction.prediction_model_name == model)
+                        )
+                    )
+                    .scalars()
+                    .one()
+                )
+                if count == len(grid_square_counts):
+                    preds = (
+                        (await session.execute(pred_query.order_by(CurrentQualityPrediction.gridsquare_uuid)))
+                        .scalars()
+                        .all()
+                    )
                 else:
                     pred_alias = aliased(CurrentQualityPrediction, pred_query.subquery())
                     gridsquare_subquery = (
@@ -240,7 +296,7 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
                         .outerjoin(pred_alias, gridsquare_alias.uuid == pred_alias.gridsquare_uuid)
                         .order_by(gridsquare_alias.uuid)
                     )
-                    preds = session.exec(preds_query).all()
+                    preds = (await session.execute(preds_query)).scalars().all()
                 ctotal = 0
                 for p, c in zip(preds, grid_square_counts, strict=True):
                     sub_values = np.ndarray(c[1])
@@ -251,17 +307,19 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
                     ctotal += c[1]
             elif model_level == ModelLevel.FOILHOLEGROUP:
                 # Build a foilhole_uuid -> value map from group predictions for this model/metric
-                group_preds = session.exec(
-                    select(FoilHoleGroupMembership.foilhole_uuid, CurrentQualityGroupPrediction.value)
-                    .where(CurrentQualityGroupPrediction.grid_uuid == grid_uuid)
-                    .where(CurrentQualityGroupPrediction.prediction_model_name == model)
-                    .where(
-                        or_(
-                            CurrentQualityGroupPrediction.metric_name == metric,
-                            CurrentQualityGroupPrediction.metric_name == None,  # noqa: E711
+                group_preds = (
+                    await session.execute(
+                        select(FoilHoleGroupMembership.foilhole_uuid, CurrentQualityGroupPrediction.value)
+                        .where(CurrentQualityGroupPrediction.grid_uuid == grid_uuid)
+                        .where(CurrentQualityGroupPrediction.prediction_model_name == model)
+                        .where(
+                            or_(
+                                CurrentQualityGroupPrediction.metric_name == metric,
+                                CurrentQualityGroupPrediction.metric_name == None,  # noqa: E711
+                            )
                         )
+                        .where(FoilHoleGroupMembership.group_uuid == CurrentQualityGroupPrediction.group_uuid)
                     )
-                    .where(FoilHoleGroupMembership.group_uuid == CurrentQualityGroupPrediction.group_uuid)
                 ).all()
                 group_value_by_fh = dict(group_preds)
                 value_matrix[imet, imod] = np.array(
@@ -273,18 +331,26 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
 
     summed = np.sum(value_matrix, axis=1)
     results = np.prod(summed, axis=0) ** (1 / len(summed))
-    overall_preds = session.exec(
-        select(OverallQualityPrediction)
-        .where(OverallQualityPrediction.grid_uuid == grid_uuid)
-        .order_by(OverallQualityPrediction.gridsquare_uuid, OverallQualityPrediction.foilhole_uuid)
-    ).all()
+    overall_preds = (
+        (
+            await session.execute(
+                select(OverallQualityPrediction)
+                .where(OverallQualityPrediction.grid_uuid == grid_uuid)
+                .order_by(OverallQualityPrediction.gridsquare_uuid, OverallQualityPrediction.foilhole_uuid)
+            )
+        )
+        .scalars()
+        .all()
+    )
     if not overall_preds:
-        ids = session.exec(
-            select(GridSquare.uuid, FoilHole.uuid)
-            .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
-            .where(FoilHole.x_location != None)  # noqa: E711
-            .where(GridSquare.uuid == grid_uuid)
-            .order_by(GridSquare.uuid, FoilHole.uuid)
+        ids = (
+            await session.execute(
+                select(GridSquare.uuid, FoilHole.uuid)
+                .where(GridSquare.uuid == FoilHole.gridsquare_uuid)
+                .where(FoilHole.x_location != None)  # noqa: E711
+                .where(GridSquare.uuid == grid_uuid)
+                .order_by(GridSquare.uuid, FoilHole.uuid)
+            )
         ).all()
         overall_preds = [
             OverallQualityPrediction(grid_uuid=grid_uuid, gridsquare_uuid=i[0], foilhole_uuid=i[1], value=float(v))
@@ -296,5 +362,5 @@ def overall_predictions_update(grid_uuid: str, session: Session) -> None:
     grid.prediction_updated_time = datetime.now()
     session.add_all(overall_preds)
     session.add(grid)
-    session.commit()
+    await session.commit()
     return None

--- a/tests/smartem_backend/test_consumer_async_handlers.py
+++ b/tests/smartem_backend/test_consumer_async_handlers.py
@@ -143,3 +143,92 @@ class TestActiveAgentSessionsHelper:
         result = asyncio.run(consumer._get_active_agent_sessions())
 
         assert result == [sentinel, sentinel]
+
+
+class TestMotionCorrectionComplete:
+    base_event = {
+        "event_type": "motion_correction.completed",
+        "micrograph_uuid": "mic-1",
+        "total_motion": 1.5,
+        "average_motion": 0.1,
+    }
+
+    def test_publishes_registered_event(self, db, monkeypatch, stub_publisher):
+        grid_row = MagicMock()
+        grid_row.grid_uuid = "grid-1"
+        db.execute.return_value.one.return_value = (grid_row,)
+        db.execute.return_value.scalars.return_value.all.return_value = []
+
+        async def _stub_check(*args, **kwargs):
+            return 0.7
+
+        async def _stub_prior(*args, **kwargs):
+            return None
+
+        async def _stub_publish(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(consumer, "_check_against_statistics", _stub_check)
+        monkeypatch.setattr(consumer, "prior_update", _stub_prior)
+        monkeypatch.setattr(consumer, "publish_motion_correction_registered", _stub_publish)
+
+        import asyncio
+
+        asyncio.run(consumer.handle_motion_correction_complete(dict(self.base_event)))
+
+        assert db.add.call_count == 1
+        assert db.commit.await_count == 1
+
+
+class TestRefreshPredictions:
+    base_event = {
+        "event_type": "refresh.predictions",
+        "grid_uuid": "grid-1",
+    }
+
+    def test_calls_predictions_helpers(self, db, monkeypatch):
+        called: list[str] = []
+
+        async def _stub_overall(grid_uuid, session):
+            called.append(f"overall:{grid_uuid}")
+
+        async def _stub_ordered(grid_uuid, session):
+            called.append(f"ordered:{grid_uuid}")
+            return []
+
+        monkeypatch.setattr(consumer, "overall_predictions_update", _stub_overall)
+        monkeypatch.setattr(consumer, "ordered_holes", _stub_ordered)
+
+        import asyncio
+
+        asyncio.run(consumer.handle_refresh_predictions(dict(self.base_event)))
+
+        assert called == ["overall:grid-1", "ordered:grid-1"]
+
+
+class TestGridCreated:
+    base_event = {
+        "event_type": "grid.created",
+        "uuid": "grid-1",
+        "name": "g1",
+        "data_directory": "/tmp/x",
+        "atlas_directory": "/tmp/x/atlas",
+        "scan_start_datetime": None,
+        "scan_end_datetime": None,
+        "instrument_id": None,
+        "acquisition_uuid": "acq-1",
+    }
+
+    def test_invokes_initialise(self, monkeypatch):
+        called: list[str] = []
+
+        async def _stub(grid_uuid, engine=None):
+            called.append(grid_uuid)
+
+        monkeypatch.setattr(consumer, "initialise_all_models_for_grid", _stub)
+
+        import asyncio
+
+        asyncio.run(consumer.handle_grid_created(dict(self.base_event)))
+
+        assert called == ["grid-1"]


### PR DESCRIPTION
## Summary

Finishes the consumer-side async migration. Removes the last 8 \`run_in_threadpool\` shims from \`consumer.py\` by converting the two helper layers that were holding them in place: the prediction helpers (\`predictions/*.py\`) and the CLI helpers (\`cli/*.py\`). After this lands, \`consumer.py\` is AsyncSession end-to-end.

## What changed

### Prediction helpers (predictions/*.py)
- \`prior_update\`, \`overall_predictions_update\` (\`predictions/update.py\`) and \`ordered_holes\` + \`get_all_scores_for_grid\` (\`predictions/acquisition.py\`) take an \`AsyncSession\` and use \`await session.execute(...)\`. Numpy / branching logic unchanged.

### CLI helpers (cli/*.py)
- All three modules: core helpers are \`async def\`, typer entry points get an \`asyncio.run(...)\` wrapper. Same pattern PR 268 used for \`api_server.py\`.
- \`simulate_processing_pipeline_async\` now uses \`asyncio.create_task\` (with a module-level set to keep strong references) instead of spawning a daemon thread. \`time.sleep\` -> \`await asyncio.sleep\`. The function name is now accurate: it actually returns to the consumer's event loop, not a thread.
- A pre-existing argument-order bug in \`perform_random_updates\` (passing \`sess\` positionally where \`metric\` was expected, then \`metric=metric\` as kwarg - would always raise \`TypeError\`) is silently corrected by the rewrite.

### Consumer (consumer.py)
- 4 cat-2 handlers (motion / CTF / particle picking complete; refresh predictions): converted to native AsyncSession blocks, await the now-async prediction helpers.
- 4 cat-3 handlers (grid / gridsquare / foilhole / micrograph created): \`await\` the now-async CLI helpers directly.
- \`_check_against_statistics\` migrated to async.
- Imports cleaned up: \`Session\`, \`run_in_threadpool\`, \`db_engine\`, \`get_db_engine\`, \`Engine\` are all gone. Only the \`async_db_engine\` and \`SessionLocal\` remain.
- The sync engine in \`utils.py\` is now used only by Alembic migrations and \`agent_data_cleanup\` (intended end state).

### Tests (test_consumer_async_handlers.py)
- 3 new smoke tests covering the cat-2 (\`handle_motion_correction_complete\`, \`handle_refresh_predictions\`) and cat-3 (\`handle_grid_created\`) patterns by patching the helpers and verifying call shape / commit count.

## Test plan

- [x] \`uv run pytest tests/\`: 158 passed, 3 skipped (was 155+3 on \`main\`; +3 new tests).
- [x] \`uv run ruff check\` / \`ruff format\`: clean.
- [x] \`uv run pyright\` across all touched files: 27 errors vs. 28 baseline - small net improvement; remaining are pre-existing SQLModel type-inference noise in the predictions code.
- [x] \`uv run pre-commit run --files ...\`: clean.
- [ ] Reviewer: e2e compressed-playback test - confirm motion-correction / CTF / particle-picking replies still reach agents and the consumer survives heartbeat starvation: \`repos/DiamondLightSource/smartem-devtools/tests/e2e/run-e2e-test.sh\`. With this PR the consumer's event loop is the only concurrency surface; threads are gone.
- [ ] Reviewer: spot-check a CLI command (e.g. \`smartem.init-model-weight --name X --weight 0.5\`) to confirm the asyncio.run wrappers work end-to-end against a live database.