### PR TITLE
perf: coalesce 4 commits in acknowledge_instruction

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -1934,15 +1934,13 @@ async def acknowledge_instruction(
         if instruction.agent_id != agent_id:
             raise HTTPException(status_code=400, detail="Instruction does not belong to this agent")
 
-        # Mark instruction as acknowledged in the database
-        if instruction.status == "sent":
-            instruction.status = "acknowledged"
-            instruction.acknowledged_at = datetime.now()
-            await db.commit()
-        else:
+        if instruction.status != "sent":
             raise HTTPException(status_code=400, detail="Instruction cannot be acknowledged (invalid status)")
 
-        # Create acknowledgement record for audit trail
+        now = datetime.now()
+        instruction.status = "acknowledged"
+        instruction.acknowledged_at = now
+
         ack_record = AgentInstructionAcknowledgement(
             instruction_id=instruction_id,
             agent_id=agent_id,
@@ -1951,21 +1949,17 @@ async def acknowledge_instruction(
             result=acknowledgement.result,
             error_message=acknowledgement.error_message,
             acknowledgement_metadata=getattr(acknowledgement, "metadata", None) or {},
-            created_at=datetime.now(),
-            processed_at=datetime.now() if acknowledgement.status in ["processed", "failed"] else None,
+            created_at=now,
+            processed_at=now if acknowledgement.status in ["processed", "failed"] else None,
         )
         db.add(ack_record)
+
+        session.last_activity_at = now
+        session_connection.last_heartbeat_at = now
+
         await db.commit()
 
         logger.info(f"Created acknowledgement for instruction {instruction_id} with status {acknowledgement.status}")
-
-        # Update session activity
-        session.last_activity_at = datetime.now()
-        await db.commit()
-
-        # Update connection heartbeat
-        session_connection.last_heartbeat_at = datetime.now()
-        await db.commit()
 
         logger.info(
             f"Instruction {instruction_id} acknowledged by agent {agent_id} with status: {acknowledgement.status}"


### PR DESCRIPTION
## Summary

Closes #255.

\`acknowledge_instruction\` previously did 4 separate \`db.commit()\` calls (status update, audit insert, session activity, connection heartbeat). Each is a round-trip + WAL fsync; under high-throughput acknowledgement load this amplifies pressure on the pool. The 4 mutations are logically one unit, so coalesce into a single transaction.

## What changed

- One \`await db.commit()\` at the end instead of four interspersed.
- All four timestamps share one \`now = datetime.now()\` so the audit row's \`created_at\` exactly matches the instruction's \`acknowledged_at\` (previously they could be tens of microseconds apart).
- The \`if instruction.status != \"sent\"\` check is hoisted above any mutation - failed validation now raises before touching the DB.
- The \"created acknowledgement\" log line moved after the commit so we only log on actual persistence.

Atomicity is a free upgrade: SQLAlchemy rolls back on exception by default, and the existing \`except\` block already produces the right HTTP response. Previously a failure on the audit insert or either timestamp update would leave the instruction marked acknowledged but the rest of the state inconsistent.

## Test plan

- [x] \`uv run pytest tests/\`: 170 passed, 3 skipped (no regression).
- [x] \`uv run pytest tests/ -k \"ack or instruction\"\`: 62 passed.
- [x] \`uv run pre-commit run --files src/smartem_backend/api_server.py\`: clean.