### PR TITLE
perf: replace SSE instruction-polling loop with PostgreSQL LISTEN/NOTIFY

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import asyncpg
 import mrcfile
 import tifffile
 from fastapi import Depends, FastAPI, HTTPException, Request, status
@@ -30,6 +31,7 @@ from smartem_backend.frontend_stream import (
     query_instruction_updates,
     query_processing_metrics,
 )
+from smartem_backend.instruction_notify import INSTRUCTION_CHANNEL, notify_instruction_pending
 from smartem_backend.model.database import (
     Acquisition,
     AgentConnection,
@@ -141,7 +143,7 @@ from smartem_backend.mq_publisher import (
 )
 from smartem_backend.rmq import AioPikaPublisher
 from smartem_backend.rmq.config import load_rmq_connection_url, load_rmq_topology
-from smartem_backend.utils import app_config, setup_postgres_async_connection
+from smartem_backend.utils import app_config, get_asyncpg_dsn, setup_postgres_async_connection
 from smartem_common._version import __version__
 
 # Initialize database connection (skip in documentation generation mode)
@@ -1675,15 +1677,86 @@ async def get_grid_latent_representation(prediction_model_name: str, grid_uuid: 
 # ============ Agent Communication Endpoints ============
 
 
+_SSE_HEARTBEAT_INTERVAL_SECONDS = 30
+
+
+async def _drain_pending_instructions(db: AsyncSession, agent_id: str, session_id: str):
+    """Yield SSE events for any pending+unexpired instructions, marking each as sent.
+
+    A single transaction per dispatched instruction (status -> sent + sent_at).
+    """
+    pending = (
+        (
+            await db.execute(
+                select(AgentInstruction)
+                .where(
+                    and_(
+                        AgentInstruction.session_id == session_id,
+                        AgentInstruction.status == "pending",
+                        or_(
+                            AgentInstruction.expires_at.is_(None),
+                            AgentInstruction.expires_at > datetime.now(),
+                        ),
+                    )
+                )
+                .order_by(
+                    AgentInstruction.priority.desc(),
+                    AgentInstruction.sequence_number.asc(),
+                    AgentInstruction.created_at.asc(),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    for instruction in pending:
+        if instruction.status == "pending":
+            instruction.status = "sent"
+            instruction.sent_at = datetime.now()
+            await db.commit()
+
+        yield {
+            "event": "instruction",
+            "data": json.dumps(
+                {
+                    "type": "instruction",
+                    "instruction_id": instruction.instruction_id,
+                    "agent_id": agent_id,
+                    "session_id": session_id,
+                    "instruction_type": instruction.instruction_type,
+                    "payload": instruction.payload,
+                    "sequence_number": instruction.sequence_number,
+                    "priority": instruction.priority,
+                    "created_at": instruction.created_at.isoformat(),
+                    "expires_at": instruction.expires_at.isoformat() if instruction.expires_at else None,
+                    "metadata": instruction.instruction_metadata,
+                }
+            ),
+        }
+        logger.info(f"Sent instruction {instruction.instruction_id} to agent {agent_id}")
+
+
 @app.get("/agent/{agent_id}/session/{session_id}/instructions/stream")
 async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession = DB_DEPENDENCY) -> EventSourceResponse:
-    """SSE endpoint for streaming instructions to agents for a specific session"""
+    """SSE endpoint for streaming instructions to agents for a specific session.
+
+    Uses PostgreSQL LISTEN/NOTIFY (channel `agent_instructions`, payload = session_id)
+    instead of polling: a dedicated asyncpg connection holds a LISTEN, the main loop
+    awaits the next notification or a heartbeat timeout, and only queries the
+    database when a notification arrives or on initial connect.
+    """
 
     async def event_generator():
         connection_id = str(uuid.uuid4())
+        listen_conn: asyncpg.Connection | None = None
+        notif_queue: asyncio.Queue[str] = asyncio.Queue()
+
+        def _on_notify(_conn, _pid, _channel, payload: str) -> None:
+            if payload == session_id:
+                notif_queue.put_nowait(payload)
 
         try:
-            # Validate session exists and belongs to agent
             try:
                 session = (
                     (await db.execute(select(AgentSession).where(AgentSession.session_id == session_id)))
@@ -1704,7 +1777,6 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
                 }
                 return
 
-            # Create database connection record
             try:
                 connection = AgentConnection(
                     connection_id=connection_id,
@@ -1733,7 +1805,6 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
                 }
                 return
 
-            # Send initial connection acknowledgment
             yield {
                 "event": "connection",
                 "data": json.dumps(
@@ -1747,12 +1818,41 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
                 ),
             }
 
-            heartbeat_counter = 0
+            # Open the dedicated LISTEN connection BEFORE the initial drain so
+            # any instruction created concurrently with the SELECT shows up as
+            # a queued notification we'll process on the next loop iteration.
+            try:
+                listen_conn = await asyncpg.connect(get_asyncpg_dsn())
+                await listen_conn.add_listener(INSTRUCTION_CHANNEL, _on_notify)
+            except Exception as e:
+                logger.error(f"Failed to set up LISTEN for session {session_id}: {e}")
+                yield {
+                    "event": "error",
+                    "data": json.dumps(
+                        {"type": "error", "error": "listen_setup_failed", "message": "Failed to subscribe"}
+                    ),
+                }
+                return
+
+            async for event in _drain_pending_instructions(db, agent_id, session_id):
+                yield event
+
+            session.last_activity_at = datetime.now()
+            await db.commit()
 
             while True:
-                # Send heartbeat every 30 seconds
-                if heartbeat_counter % 6 == 0:  # Every 6th iteration (30 seconds)
-                    # Update connection heartbeat
+                try:
+                    await asyncio.wait_for(notif_queue.get(), timeout=_SSE_HEARTBEAT_INTERVAL_SECONDS)
+                    while not notif_queue.empty():
+                        notif_queue.get_nowait()
+                    try:
+                        async for event in _drain_pending_instructions(db, agent_id, session_id):
+                            yield event
+                    except Exception as e:
+                        logger.error(f"Error processing instructions for session {session_id}: {e}")
+                    session.last_activity_at = datetime.now()
+                    await db.commit()
+                except TimeoutError:
                     connection_obj = (
                         (
                             await db.execute(
@@ -1776,73 +1876,8 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
                         ),
                     }
 
-                # Check for pending instructions
-                try:
-                    pending_instructions = (
-                        (
-                            await db.execute(
-                                select(AgentInstruction)
-                                .where(
-                                    and_(
-                                        AgentInstruction.session_id == session_id,
-                                        AgentInstruction.status == "pending",
-                                        or_(
-                                            AgentInstruction.expires_at.is_(None),
-                                            AgentInstruction.expires_at > datetime.now(),
-                                        ),
-                                    )
-                                )
-                                .order_by(
-                                    AgentInstruction.priority.desc(),  # High priority first
-                                    AgentInstruction.sequence_number.asc(),  # Lower sequence numbers first
-                                    AgentInstruction.created_at.asc(),  # Older instructions first
-                                )
-                            )
-                        )
-                        .scalars()
-                        .all()
-                    )
-
-                    for instruction in pending_instructions:
-                        # Mark as sent
-                        if instruction.status == "pending":
-                            instruction.status = "sent"
-                            instruction.sent_at = datetime.now()
-                            await db.commit()
-
-                        # Send instruction to agent
-                        instruction_data = {
-                            "type": "instruction",
-                            "instruction_id": instruction.instruction_id,
-                            "agent_id": agent_id,
-                            "session_id": session_id,
-                            "instruction_type": instruction.instruction_type,
-                            "payload": instruction.payload,
-                            "sequence_number": instruction.sequence_number,
-                            "priority": instruction.priority,
-                            "created_at": instruction.created_at.isoformat(),
-                            "expires_at": instruction.expires_at.isoformat() if instruction.expires_at else None,
-                            "metadata": instruction.instruction_metadata,
-                        }
-
-                        yield {"event": "instruction", "data": json.dumps(instruction_data)}
-
-                        logger.info(f"Sent instruction {instruction.instruction_id} to agent {agent_id}")
-
-                except Exception as e:
-                    logger.error(f"Error processing instructions for session {session_id}: {e}")
-
-                # Update session activity
-                session.last_activity_at = datetime.now()
-                await db.commit()
-
-                # Wait 5 seconds before next poll
-                await asyncio.sleep(5)
-                heartbeat_counter += 1
-
         except asyncio.CancelledError:
             logger.info(f"SSE connection closed for agent {agent_id}, session {session_id}")
-            # Connection closed by client
             connection_obj = (
                 (await db.execute(select(AgentConnection).where(AgentConnection.connection_id == connection_id)))
                 .scalars()
@@ -1857,7 +1892,6 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
             raise
         except Exception as e:
             logger.error(f"SSE stream error for agent {agent_id}: {e}")
-            # Unexpected error
             connection_obj = (
                 (await db.execute(select(AgentConnection).where(AgentConnection.connection_id == connection_id)))
                 .scalars()
@@ -1870,6 +1904,16 @@ async def stream_instructions(agent_id: str, session_id: str, db: AsyncSession =
                 await db.commit()
                 logger.info(f"Closed connection {connection_id} with reason: error: {str(e)}")
             raise
+        finally:
+            if listen_conn is not None:
+                try:
+                    await listen_conn.remove_listener(INSTRUCTION_CHANNEL, _on_notify)
+                except Exception as e:
+                    logger.warning(f"Failed to remove LISTEN listener for session {session_id}: {e}")
+                try:
+                    await listen_conn.close()
+                except Exception as e:
+                    logger.warning(f"Failed to close LISTEN connection for session {session_id}: {e}")
 
     return EventSourceResponse(event_generator())
 
@@ -2254,6 +2298,7 @@ async def create_test_instruction(session_id: str, instruction_data: dict, db: A
         instruction_metadata=instruction_data.get("metadata", {}),
     )
     db.add(instruction)
+    await notify_instruction_pending(db, session_id)
     await db.commit()
 
     logger.info(f"Created instruction {instruction.instruction_id} for session {session_id}")

--- a/src/smartem_backend/consumer.py
+++ b/src/smartem_backend/consumer.py
@@ -26,6 +26,7 @@ from smartem_backend.cli.random_model_predictions import (
     generate_predictions_for_gridsquare,
 )
 from smartem_backend.cli.random_prior_updates import simulate_processing_pipeline_async
+from smartem_backend.instruction_notify import notify_instruction_pending
 from smartem_backend.log_manager import LogConfig, LogManager
 from smartem_backend.model.database import (
     AgentInstruction,
@@ -1004,6 +1005,7 @@ async def handle_agent_instruction_created(event_data: dict[str, Any]) -> None:
                 instruction_metadata=event.instruction_metadata or {},
             )
             session.add(instruction)
+            await notify_instruction_pending(session, event.session_id)
             await session.commit()
         logger.info(f"Successfully persisted instruction {event.instruction_id} to database")
     except ValidationError as e:
@@ -1066,6 +1068,7 @@ async def handle_agent_instruction_expired(event_data: dict[str, Any]) -> None:
                 instruction.status = "pending"
                 instruction.retry_count = event.retry_count
                 resolution = "retry"
+                await notify_instruction_pending(session, instruction.session_id)
             await session.commit()
         if resolution == "expired":
             logger.info(f"Instruction {event.instruction_id} marked as expired after {event.retry_count} retries")

--- a/src/smartem_backend/instruction_notify.py
+++ b/src/smartem_backend/instruction_notify.py
@@ -1,0 +1,27 @@
+"""PostgreSQL LISTEN/NOTIFY plumbing for agent instruction delivery.
+
+Replaces the steady-state polling that the SSE instruction stream used to do.
+Writers issue NOTIFY in the same transaction as the INSERT/UPDATE; the SSE
+handler holds a dedicated asyncpg connection LISTENing on this channel and
+wakes only when a notification for its session arrives.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+INSTRUCTION_CHANNEL = "agent_instructions"
+
+
+async def notify_instruction_pending(session: AsyncSession, agent_session_id: str) -> None:
+    """Queue a NOTIFY for `agent_session_id` on the instruction channel.
+
+    PostgreSQL fires queued NOTIFYs on COMMIT, so this must be called before
+    the caller's commit. The notification reaches LISTENers atomically with
+    the row mutation that motivates it.
+    """
+    await session.execute(
+        text("SELECT pg_notify(:channel, :payload)"),
+        {"channel": INSTRUCTION_CHANNEL, "payload": agent_session_id},
+    )

--- a/src/smartem_backend/utils.py
+++ b/src/smartem_backend/utils.py
@@ -141,6 +141,19 @@ def _async_postgres_url() -> str:
     )
 
 
+def get_asyncpg_dsn() -> str:
+    """Return a DSN suitable for `asyncpg.connect()` (no SQLAlchemy driver suffix).
+
+    Used for dedicated asyncpg connections that need bare-driver behaviour, e.g.
+    LISTEN/NOTIFY listeners that live outside the SQLAlchemy session pool.
+    """
+    env = _load_postgres_env()
+    return (
+        f"postgresql://{env['POSTGRES_USER']}:{env['POSTGRES_PASSWORD']}"
+        f"@{env['POSTGRES_HOST']}:{env['POSTGRES_PORT']}/{env['POSTGRES_DB']}"
+    )
+
+
 def setup_postgres_connection(echo=False, force_new=False) -> Engine:
     """
     Get or create a singleton database engine with connection pooling.

--- a/tests/smartem_backend/test_instruction_notify.py
+++ b/tests/smartem_backend/test_instruction_notify.py
@@ -1,0 +1,27 @@
+"""Verify the NOTIFY helper issues the right SQL and that writers wire it in."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+os.environ["SKIP_DB_INIT"] = "true"
+
+import pytest
+
+from smartem_backend.instruction_notify import INSTRUCTION_CHANNEL, notify_instruction_pending
+
+
+class TestNotifyHelper:
+    @pytest.mark.asyncio
+    async def test_emits_pg_notify_with_session_id_payload(self):
+        session = MagicMock()
+        session.execute = AsyncMock()
+
+        await notify_instruction_pending(session, "sess-abc")
+
+        assert session.execute.await_count == 1
+        stmt, params = session.execute.await_args.args
+        assert "pg_notify" in str(stmt).lower()
+        assert params == {"channel": INSTRUCTION_CHANNEL, "payload": "sess-abc"}
+
+    def test_channel_is_stable(self):
+        assert INSTRUCTION_CHANNEL == "agent_instructions"


### PR DESCRIPTION
## Summary

Closes #256.

The instruction-stream SSE endpoint (\`/agent/{agent_id}/session/{session_id}/instructions/stream\`) used to wake every 5 seconds and SELECT \`WHERE status='pending'\` for its session, regardless of whether any instruction existed. With N connected agents that's N SELECTs per 5s of idle background load, plus an up-to-5s delivery latency for every new instruction.

This PR replaces the polling loop with a PostgreSQL \`LISTEN/NOTIFY\` subscription, leveraging the AsyncSession foundation that landed in #266-271.

## How it works

**Writer side** - new \`smartem_backend.instruction_notify\` module:
- Constant \`INSTRUCTION_CHANNEL = \"agent_instructions\"\`.
- \`notify_instruction_pending(session, agent_session_id)\` issues \`SELECT pg_notify(:channel, :payload)\` via the AsyncSession. Postgres queues NOTIFYs and fires them on COMMIT, so notification and the visible row mutation become atomic.

Three writer sites wired up:
- \`consumer.handle_agent_instruction_created\` - main creator path.
- \`consumer.handle_agent_instruction_expired\` - only on the retry-back-to-pending branch (status=expired branch doesn't notify).
- \`api_server\` debug \`/debug/session/{session_id}/create-instruction\` endpoint.

**Listener side** - rewrote \`stream_instructions\`:
- Opens a dedicated \`asyncpg.connect()\` at start (not from the pool), \`LISTEN\`s on \`agent_instructions\`, and registers a sync callback that filters payloads by \`session_id\` and pushes matches into an \`asyncio.Queue\`.
- After session validation + connection record creation, drains any already-pending instructions once.
- Main loop: \`asyncio.wait_for(notif_queue.get(), timeout=30)\`. On notify: drain queue + SELECT pending. On timeout: emit heartbeat (and bump \`AgentConnection.last_heartbeat_at\`).
- \`finally\`: \`remove_listener\` + close the dedicated connection.
- The pending-drain is factored into a small \`_drain_pending_instructions\` async-generator helper, so the initial-flush and on-notify paths share the same code (including the per-instruction status-flip + commit).

**DSN helper** - \`utils.get_asyncpg_dsn()\` returns the bare-driver DSN (\`postgresql://...\` without the \`+asyncpg\` SQLAlchemy prefix) for the listener connection.

## Resource cost

Each SSE client now holds 2 DB connections: 1 pool slot for the AsyncSession (ORM operations) and 1 dedicated asyncpg connection for LISTEN. The dedicated connection sits idle except when notifications arrive, and doesn't compete with regular API throughput. Acceptable trade for eliminating polling.

## Test plan

- [x] \`uv run pytest tests/\`: 172 passed, 3 skipped (was 170+3; +2 new tests for the NOTIFY helper).
- [x] \`uv run ruff check\` / \`ruff format\`: clean.
- [x] \`uv run pyright\`: \`api_server.py\` 170 vs. 169 baseline (+1 net for the rewrite, in line with the per-rewrite tolerance from #268). \`instruction_notify.py\` and \`utils.py\` clean.
- [x] \`uv run pre-commit run --files ...\`: clean.
- [ ] Reviewer: spin up a dev cluster, open an SSE stream, POST a debug instruction, verify the agent sees it within ~100ms (was up to 5s).
- [ ] Reviewer: \`SELECT pid, application_name FROM pg_stat_activity WHERE state='idle'\` should show one extra connection per active SSE client (the listener), plus the existing pool connections.