### PR TITLE
test: TestClient coverage for acquisitions, grids, prediction_models

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -381,7 +381,7 @@ async def create_acquisition(acquisition: AcquisitionCreateRequest, db: AsyncSes
     acquisition_data = {
         "uuid": acquisition.uuid,
         "status": AcquisitionStatus.STARTED,
-        **acquisition.model_dump(exclude={"uuid"}),
+        **acquisition.model_dump(exclude={"uuid", "status"}),
     }
     db_acquisition = Acquisition(**acquisition_data)
     db.add(db_acquisition)
@@ -556,7 +556,7 @@ async def create_acquisition_grid(acquisition_uuid: str, grid: GridCreateRequest
         "uuid": grid.uuid,
         "acquisition_uuid": acquisition_uuid,
         "status": GridStatus.NONE,
-        **grid.model_dump(),
+        **grid.model_dump(exclude={"uuid", "acquisition_uuid", "status"}),
     }
     db_grid = Grid(**grid_data)
     db.add(db_grid)
@@ -570,11 +570,8 @@ async def create_acquisition_grid(acquisition_uuid: str, grid: GridCreateRequest
         "uuid": grid.uuid,
         "acquisition_uuid": acquisition_uuid,
         "status": GridStatus.NONE,
-        **grid.model_dump(),
+        **grid.model_dump(exclude={"uuid", "acquisition_uuid", "status"}),
     }
-
-    if "status" not in response_data or response_data["status"] is None:
-        response_data["status"] = GridStatus.NONE
 
     return GridResponse(**response_data)
 

--- a/tests/smartem_backend/conftest.py
+++ b/tests/smartem_backend/conftest.py
@@ -1,0 +1,80 @@
+"""Shared fixtures for FastAPI TestClient-based endpoint tests.
+
+The pattern (established in `test_processing_feedback_endpoints.py` and
+`test_batch_gridsquare_creation.py`):
+
+- Set `SKIP_DB_INIT=true` before importing api_server so the SQLAlchemy
+  engine is never built.
+- Override `get_db` with a `make_async_db()` mock; tests assert on
+  `db.add` / `db.commit` / `db.execute` and tweak `db.execute.return_value`
+  for not-found / no-row cases.
+- Tests monkeypatch the individual `publish_*` helpers they care about.
+
+This conftest lifts the boilerplate out of each new test file. Do NOT
+import `api_server` at module level here - the SKIP_DB_INIT env var must
+be set first, and the existing per-file pattern (set env var, then import)
+is the cleanest way to keep that ordering explicit at the test-file level.
+"""
+
+import os
+
+os.environ.setdefault("SKIP_DB_INIT", "true")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from smartem_backend import api_server
+from smartem_backend.api_server import app, get_db
+
+from ._async_db_stub import make_async_db, make_execute_result
+
+
+@pytest.fixture
+def db():
+    """Fresh AsyncSession-shaped mock per test."""
+    return make_async_db()
+
+
+@pytest.fixture
+def client(db):
+    """TestClient with `get_db` overridden. The mock db is reachable as `client._db`."""
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        with TestClient(app) as tc:
+            tc._db = db
+            yield tc
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture
+def stub_publisher(monkeypatch):
+    """Factory for stubbing `api_server.publish_*` helpers with a shared call log.
+
+    Usage:
+        calls = stub_publisher("publish_acquisition_created")
+        ...
+        assert calls[0]["uuid"] == "acq-1"
+
+    The factory returns a list that future invocations append a kwargs-dict to.
+    Returns True by default (publish succeeded). Use `stub_publisher(..., return_value=False)`
+    to simulate publish failure.
+    """
+
+    def _factory(name: str, return_value: bool = True) -> list:
+        calls: list[dict] = []
+
+        async def _fake(*args, **kwargs):
+            entry = {"args": args, **kwargs} if args else kwargs
+            calls.append(entry)
+            return return_value
+
+        monkeypatch.setattr(api_server, name, _fake)
+        return calls
+
+    return _factory
+
+
+def set_db_row(client: TestClient, row) -> None:
+    """Convenience: have the next `db.execute(...).scalars().first()/one()` return `row`."""
+    client._db.execute.return_value = make_execute_result(row)

--- a/tests/smartem_backend/test_acquisitions.py
+++ b/tests/smartem_backend/test_acquisitions.py
@@ -1,0 +1,117 @@
+"""TestClient coverage for the /acquisitions endpoints (issue #258)."""
+
+from .conftest import set_db_row
+
+
+def _payload(uuid: str = "acq-1", **overrides) -> dict:
+    base = {
+        "uuid": uuid,
+        "name": "test-acquisition",
+        "instrument_id": "inst-1",
+        "computer_name": "test-host",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestListAcquisitions:
+    def test_returns_empty_list_when_no_rows(self, client):
+        set_db_row(client, [])
+        resp = client.get("/acquisitions")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestCreateAcquisition:
+    def test_happy_path_persists_and_publishes(self, client, stub_publisher):
+        calls = stub_publisher("publish_acquisition_created")
+        resp = client.post("/acquisitions", json=_payload())
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["uuid"] == "acq-1"
+        assert body["name"] == "test-acquisition"
+        assert body["status"] == "started"
+
+        client._db.add.assert_called_once()
+        client._db.commit.assert_called_once()
+        assert len(calls) == 1
+        assert calls[0]["uuid"] == "acq-1"
+        assert calls[0]["status"] == "started"
+
+    def test_missing_uuid_returns_422(self, client, stub_publisher):
+        calls = stub_publisher("publish_acquisition_created")
+        resp = client.post("/acquisitions", json={"name": "no-uuid"})
+        assert resp.status_code == 422
+        client._db.add.assert_not_called()
+        assert calls == []
+
+    def test_publish_failure_still_returns_201(self, client, stub_publisher):
+        stub_publisher("publish_acquisition_created", return_value=False)
+        resp = client.post("/acquisitions", json=_payload())
+        assert resp.status_code == 201
+
+
+class TestGetAcquisition:
+    def test_404_when_not_found(self, client):
+        set_db_row(client, None)
+        resp = client.get("/acquisitions/missing")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Acquisition not found"
+
+
+class TestUpdateAcquisition:
+    def test_happy_path_persists_and_publishes(self, client, stub_publisher):
+        from smartem_backend.model.database import Acquisition
+        from smartem_backend.model.entity_status import AcquisitionStatus
+
+        existing = Acquisition(
+            uuid="acq-1",
+            id=42,
+            name="old",
+            status=AcquisitionStatus.STARTED,
+            instrument_id="inst-1",
+            computer_name="test-host",
+        )
+        set_db_row(client, existing)
+        calls = stub_publisher("publish_acquisition_updated")
+
+        resp = client.put("/acquisitions/acq-1", json={"name": "new"})
+
+        assert resp.status_code == 200
+        client._db.commit.assert_called_once()
+        assert len(calls) == 1
+        assert calls[0]["uuid"] == "acq-1"
+        assert calls[0]["id"] == 42
+
+    def test_404_when_not_found(self, client, stub_publisher):
+        set_db_row(client, None)
+        calls = stub_publisher("publish_acquisition_updated")
+        resp = client.put("/acquisitions/missing", json={"name": "x"})
+        assert resp.status_code == 404
+        client._db.commit.assert_not_called()
+        assert calls == []
+
+
+class TestDeleteAcquisition:
+    def test_happy_path_returns_204_and_publishes(self, client, stub_publisher):
+        from smartem_backend.model.database import Acquisition
+
+        existing = Acquisition(uuid="acq-1", name="to-delete")
+        set_db_row(client, existing)
+        calls = stub_publisher("publish_acquisition_deleted")
+
+        resp = client.delete("/acquisitions/acq-1")
+
+        assert resp.status_code == 204
+        client._db.delete.assert_awaited_once()
+        client._db.commit.assert_called_once()
+        assert calls == [{"uuid": "acq-1"}]
+
+    def test_404_when_not_found(self, client, stub_publisher):
+        set_db_row(client, None)
+        calls = stub_publisher("publish_acquisition_deleted")
+        resp = client.delete("/acquisitions/missing")
+        assert resp.status_code == 404
+        client._db.delete.assert_not_called()
+        assert calls == []

--- a/tests/smartem_backend/test_grids.py
+++ b/tests/smartem_backend/test_grids.py
@@ -1,0 +1,117 @@
+"""TestClient coverage for the /grids and /acquisitions/{uuid}/grids endpoints (issue #258)."""
+
+from .conftest import set_db_row
+
+
+def _grid_payload(uuid: str = "grid-1", **overrides) -> dict:
+    base = {
+        "uuid": uuid,
+        "name": "test-grid",
+        "acquisition_uuid": "acq-1",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestListGrids:
+    def test_returns_empty_list(self, client):
+        set_db_row(client, [])
+        resp = client.get("/grids")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestGetGrid:
+    def test_404_when_not_found(self, client):
+        set_db_row(client, None)
+        resp = client.get("/grids/missing")
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Grid not found"
+
+
+class TestUpdateGrid:
+    def test_happy_path_publishes(self, client, stub_publisher):
+        from smartem_backend.model.database import Grid
+        from smartem_backend.model.entity_status import GridStatus
+
+        existing = Grid(
+            uuid="grid-1",
+            acquisition_uuid="acq-1",
+            name="old",
+            status=GridStatus.NONE,
+        )
+        set_db_row(client, existing)
+        calls = stub_publisher("publish_grid_updated")
+
+        resp = client.put("/grids/grid-1", json={"name": "new"})
+
+        assert resp.status_code == 200
+        client._db.commit.assert_called_once()
+        assert calls == [{"uuid": "grid-1", "acquisition_uuid": "acq-1"}]
+
+    def test_404_when_not_found(self, client, stub_publisher):
+        set_db_row(client, None)
+        calls = stub_publisher("publish_grid_updated")
+        resp = client.put("/grids/missing", json={"name": "x"})
+        assert resp.status_code == 404
+        assert calls == []
+
+
+class TestDeleteGrid:
+    def test_happy_path_publishes(self, client, stub_publisher):
+        from smartem_backend.model.database import Grid
+
+        set_db_row(client, Grid(uuid="grid-1", acquisition_uuid="acq-1", name="g"))
+        calls = stub_publisher("publish_grid_deleted")
+
+        resp = client.delete("/grids/grid-1")
+        assert resp.status_code == 204
+        assert calls == [{"uuid": "grid-1"}]
+
+    def test_404_when_not_found(self, client, stub_publisher):
+        set_db_row(client, None)
+        calls = stub_publisher("publish_grid_deleted")
+        resp = client.delete("/grids/missing")
+        assert resp.status_code == 404
+        assert calls == []
+
+
+class TestListAcquisitionGrids:
+    def test_returns_empty_list(self, client):
+        set_db_row(client, [])
+        resp = client.get("/acquisitions/acq-1/grids")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestCreateAcquisitionGrid:
+    def test_happy_path_persists_and_publishes(self, client, stub_publisher):
+        calls = stub_publisher("publish_grid_created")
+
+        resp = client.post("/acquisitions/acq-1/grids", json=_grid_payload())
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["uuid"] == "grid-1"
+        assert body["acquisition_uuid"] == "acq-1"
+        assert body["status"] == "none"
+
+        client._db.add.assert_called_once()
+        client._db.commit.assert_called_once()
+        assert calls == [{"uuid": "grid-1", "acquisition_uuid": "acq-1"}]
+
+    def test_missing_required_field_returns_422(self, client, stub_publisher):
+        calls = stub_publisher("publish_grid_created")
+        resp = client.post("/acquisitions/acq-1/grids", json={"uuid": "grid-1"})
+        assert resp.status_code == 422
+        client._db.add.assert_not_called()
+        assert calls == []
+
+
+class TestGridRegistered:
+    def test_publishes_and_returns_success(self, client, stub_publisher):
+        calls = stub_publisher("publish_grid_registered")
+        resp = client.post("/grids/grid-1/registered")
+        assert resp.status_code == 200
+        assert resp.json() is True
+        assert len(calls) == 1

--- a/tests/smartem_backend/test_prediction_models.py
+++ b/tests/smartem_backend/test_prediction_models.py
@@ -1,0 +1,88 @@
+"""TestClient coverage for the /prediction_models endpoints (issue #258)."""
+
+from .conftest import set_db_row
+
+
+def _payload(name: str = "model-a", **overrides) -> dict:
+    base = {"name": name, "description": "test model"}
+    base.update(overrides)
+    return base
+
+
+class TestListPredictionModels:
+    def test_returns_empty_list(self, client):
+        set_db_row(client, [])
+        resp = client.get("/prediction_models")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestGetPredictionModel:
+    def test_404_when_not_found(self, client):
+        set_db_row(client, None)
+        resp = client.get("/prediction_models/missing")
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    def test_happy_path_returns_model(self, client):
+        from smartem_backend.model.database import QualityPredictionModel
+
+        set_db_row(client, QualityPredictionModel(name="model-a", description="desc"))
+        resp = client.get("/prediction_models/model-a")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "model-a"
+
+
+class TestCreatePredictionModel:
+    def test_happy_path_when_name_unique(self, client):
+        set_db_row(client, None)  # no existing
+        resp = client.post("/prediction_models", json=_payload())
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "model-a"
+        client._db.add.assert_called_once()
+        client._db.commit.assert_called_once()
+
+    def test_409_when_name_already_exists(self, client):
+        from smartem_backend.model.database import QualityPredictionModel
+
+        set_db_row(client, QualityPredictionModel(name="model-a"))
+        resp = client.post("/prediction_models", json=_payload())
+        assert resp.status_code == 409
+        client._db.add.assert_not_called()
+
+    def test_missing_name_returns_422(self, client):
+        resp = client.post("/prediction_models", json={"description": "no name"})
+        assert resp.status_code == 422
+
+
+class TestUpdatePredictionModel:
+    def test_happy_path(self, client):
+        from smartem_backend.model.database import QualityPredictionModel
+
+        set_db_row(client, QualityPredictionModel(name="model-a", description="old"))
+        resp = client.put("/prediction_models/model-a", json={"description": "new"})
+        assert resp.status_code == 200
+        client._db.commit.assert_called_once()
+
+    def test_404_when_not_found(self, client):
+        set_db_row(client, None)
+        resp = client.put("/prediction_models/missing", json={"description": "x"})
+        assert resp.status_code == 404
+        client._db.commit.assert_not_called()
+
+
+class TestDeletePredictionModel:
+    def test_happy_path_returns_204(self, client):
+        from smartem_backend.model.database import QualityPredictionModel
+
+        set_db_row(client, QualityPredictionModel(name="model-a"))
+        resp = client.delete("/prediction_models/model-a")
+        assert resp.status_code == 204
+        client._db.delete.assert_awaited_once()
+        client._db.commit.assert_called_once()
+
+    def test_404_when_not_found(self, client):
+        set_db_row(client, None)
+        resp = client.delete("/prediction_models/missing")
+        assert resp.status_code == 404
+        client._db.delete.assert_not_called()


### PR DESCRIPTION
## Summary

First focused pass at #258. Establishes shared TestClient fixtures plus 29 tests across three resource families covering ~17 of the ~85 endpoints in \`api_server.py\`. The pattern is set up so each new resource is one small file mirroring the same fixture surface - the rest of #258 becomes mechanical extension work.

## Foundation

\`tests/smartem_backend/conftest.py\` lifts the boilerplate that was previously copy-pasted across each test file. Provides:

- \`db\`: fresh \`make_async_db()\` mock per test.
- \`client\`: TestClient with \`get_db\` dependency override; the mock is reachable as \`client._db\`.
- \`stub_publisher(name)\`: factory for monkeypatching any \`api_server.publish_*\` helper. Returns a list that captures every call. Accepts both positional and keyword args (most publishers use kwargs, \`publish_grid_registered\` is positional).
- \`set_db_row(client, row)\`: helper for setting the next \`db.execute(...).scalars().first()/one()\` return value (e.g. \`set_db_row(client, None)\` for a 404 path).

## Coverage in this PR

- \`test_acquisitions.py\` (9 tests): list / get / create / update / delete + 404 + 422 + publish-failure.
- \`test_grids.py\` (10 tests): \`/grids\` CRUD + nested under \`/acquisitions\` + \`/grids/{uuid}/registered\`.
- \`test_prediction_models.py\` (10 tests): full CRUD + 409 on duplicate name + 404 on missing.

## Bug fixes surfaced

Two latent bugs fell out of the new tests; both are dict-spread ordering issues that would have manifested as 500s in production whenever the client omitted an optional enum field:

1. **\`create_acquisition\`**: \`AcquisitionCreateRequest.status\` is \`Optional\` and defaults to \`None\`. The dict-spread \`**acquisition.model_dump(exclude={\"uuid\"})\` came AFTER the explicit \`\"status\": AcquisitionStatus.STARTED\`, so when the request omitted status, the explicit value got overwritten with None - then \`db_acquisition.status.value\` in the publish call raised \`AttributeError: 'NoneType' object has no attribute 'value'\`. Fixed by adding \`\"status\"\` to the exclude set.

2. **\`create_acquisition_grid\`**: identical pattern with \`GridStatus.NONE\`. Same fix. Also dropped a now-redundant \`if status is None: response_data[\"status\"] = GridStatus.NONE\` patch-up that the previous author had added to mask the symptom without addressing the cause.

## Test plan

- [x] \`uv run pytest tests/\`: 201 passed, 3 skipped (was 172+3; +29 new endpoint tests).
- [x] \`uv run ruff check\` / \`ruff format\`: clean.
- [x] \`uv run pre-commit run --files ...\`: clean.
- [x] All existing tests still pass (the conftest doesn't change behaviour for tests that don't use the new fixtures).

## Follow-up scope

Still uncovered, intentionally deferred:
- atlases / atlas-tiles (~11 endpoints)
- gridsquares / foilholes / micrographs CRUD (~20 endpoints; \`/grids/{uuid}/gridsquares/batch\` already covered in \`test_batch_gridsquare_creation.py\`)
- agent/session/instruction endpoints other than the ack already covered in \`test_processing_feedback_endpoints.py\` (~10 endpoints)
- debug endpoints (~7 endpoints)
- Image-serving endpoints (need MRC fixtures - separate effort)
- SSE endpoints (\`stream_instructions\`, \`frontend_event_stream\` - testing async generators with TestClient is fiddly - separate effort)

Each remaining resource family is roughly the same 100-150 line shape as the three landed here.