### PR TITLE
feat: add capability flags to QualityPredictionModel (#238)

### DIFF
--- a/src/smartem_backend/migrations/versions/2026_04_28_1119-c4d5e6f7a8b9_add_prediction_model_capability_flags.py
+++ b/src/smartem_backend/migrations/versions/2026_04_28_1119-c4d5e6f7a8b9_add_prediction_model_capability_flags.py
@@ -1,0 +1,36 @@
+"""Add can_train, can_infer, can_update flags to qualitypredictionmodel
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-04-28 11:19:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c4d5e6f7a8b9"
+down_revision = "b3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "qualitypredictionmodel",
+        sa.Column("can_train", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "qualitypredictionmodel",
+        sa.Column("can_infer", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        "qualitypredictionmodel",
+        sa.Column("can_update", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("qualitypredictionmodel", "can_update")
+    op.drop_column("qualitypredictionmodel", "can_infer")
+    op.drop_column("qualitypredictionmodel", "can_train")

--- a/src/smartem_backend/model/database.py
+++ b/src/smartem_backend/model/database.py
@@ -241,6 +241,9 @@ class QualityPredictionModel(SQLModel, table=True):
     name: str = Field(primary_key=True)
     description: str = ""
     level: ModelLevel = Field(default=ModelLevel.GRIDSQUARE, sa_column=Column(ModelLevelType))
+    can_train: bool = Field(default=False)
+    can_infer: bool = Field(default=True)
+    can_update: bool = Field(default=False)
     parameters: list["QualityPredictionModelParameter"] = Relationship(back_populates="model", cascade_delete=True)
     weights: list["QualityPredictionModelWeight"] = Relationship(back_populates="model", cascade_delete=True)
     predictions: list["QualityPrediction"] = Relationship(back_populates="model", cascade_delete=True)

--- a/src/smartem_backend/model/http_request.py
+++ b/src/smartem_backend/model/http_request.py
@@ -327,10 +327,16 @@ class QualityPredictionModelBaseFields(BaseModel):
 class QualityPredictionModelCreateRequest(BaseModel):
     name: str
     description: str = ""
+    can_train: bool = False
+    can_infer: bool = True
+    can_update: bool = False
 
 
 class QualityPredictionModelUpdateRequest(BaseModel):
     description: str | None = None
+    can_train: bool | None = None
+    can_infer: bool | None = None
+    can_update: bool | None = None
 
 
 class QualityPredictionCreateRequest(BaseModel):

--- a/src/smartem_backend/model/http_response.py
+++ b/src/smartem_backend/model/http_response.py
@@ -196,6 +196,9 @@ class MicrographResponse(BaseModel):
 class QualityPredictionModelResponse(BaseModel):
     name: str
     description: str
+    can_train: bool
+    can_infer: bool
+    can_update: bool
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/smartem_backend/test_prediction_models.py
+++ b/tests/smartem_backend/test_prediction_models.py
@@ -30,7 +30,11 @@ class TestGetPredictionModel:
         set_db_row(client, QualityPredictionModel(name="model-a", description="desc"))
         resp = client.get("/prediction_models/model-a")
         assert resp.status_code == 200
-        assert resp.json()["name"] == "model-a"
+        body = resp.json()
+        assert body["name"] == "model-a"
+        assert body["can_train"] is False
+        assert body["can_infer"] is True
+        assert body["can_update"] is False
 
 
 class TestCreatePredictionModel:
@@ -38,9 +42,25 @@ class TestCreatePredictionModel:
         set_db_row(client, None)  # no existing
         resp = client.post("/prediction_models", json=_payload())
         assert resp.status_code == 201
-        assert resp.json()["name"] == "model-a"
+        body = resp.json()
+        assert body["name"] == "model-a"
+        assert body["can_train"] is False
+        assert body["can_infer"] is True
+        assert body["can_update"] is False
         client._db.add.assert_called_once()
         client._db.commit.assert_called_once()
+
+    def test_create_with_capability_flags(self, client):
+        set_db_row(client, None)
+        resp = client.post(
+            "/prediction_models",
+            json=_payload(can_train=True, can_infer=False, can_update=True),
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["can_train"] is True
+        assert body["can_infer"] is False
+        assert body["can_update"] is True
 
     def test_409_when_name_already_exists(self, client):
         from smartem_backend.model.database import QualityPredictionModel
@@ -63,6 +83,21 @@ class TestUpdatePredictionModel:
         resp = client.put("/prediction_models/model-a", json={"description": "new"})
         assert resp.status_code == 200
         client._db.commit.assert_called_once()
+
+    def test_update_capability_flags(self, client):
+        from smartem_backend.model.database import QualityPredictionModel
+
+        existing = QualityPredictionModel(name="model-a", description="old")
+        set_db_row(client, existing)
+        resp = client.put(
+            "/prediction_models/model-a",
+            json={"can_train": True, "can_update": True},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["can_train"] is True
+        assert body["can_infer"] is True
+        assert body["can_update"] is True
 
     def test_404_when_not_found(self, client):
         set_db_row(client, None)


### PR DESCRIPTION
## Summary

- Adds three boolean columns to the `qualitypredictionmodel` table — `can_train`, `can_infer`, `can_update` — so the frontend models tab can surface which lifecycle phases each model supports
- Exposes the flags on the create/update request schemas and the response schema
- Migration backfills existing rows via `server_default` (false / true / false)

Closes #238 on the backend side; frontend changes will follow in a separate PR.

## Notes

- Defaults match Dan's note in the issue — `can_infer` defaults to true since inference is effectively always on, the other two default to false
- No endpoint logic changes were needed: the existing handlers use `request.model_dump()` for create and `model_dump(exclude_unset=True)` for update, so new fields flow through automatically; the response uses `from_attributes=True`
- Migration revision `c4d5e6f7a8b9`, parented on `b3c4d5e6f7a8`

## Test plan

- [x] `uv run pytest tests/smartem_backend/test_prediction_models.py` — 12/12 pass, including new cases for create-with-flags and update-flags
- [x] `pre-commit run --files <changed>` clean
- [x] pyright clean for the changed code (pre-existing errors elsewhere in `http_request.py` are unrelated)
- [x] `alembic upgrade head` against a throwaway PostgreSQL — columns added with correct types/defaults, pre-existing rows backfilled, `alembic downgrade -1` cleanly removes them, re-upgrade is idempotent