### PR TITLE
fix: gridsquare PUT KeyError and create-resource path precedence (#278, #279)

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -894,7 +894,7 @@ async def update_gridsquare(
     if not db_gridsquare:
         raise HTTPException(status_code=404, detail="Grid Square not found")
     update_data = gridsquare.model_dump(exclude_unset=True)
-    if update_data["status"] == GridSquareStatus.NONE:
+    if update_data.get("status", GridSquareStatus.NONE) == GridSquareStatus.NONE:
         update_data["status"] = db_gridsquare.status
     for key, value in update_data.items():
         if hasattr(db_gridsquare, key):
@@ -970,10 +970,10 @@ async def create_grid_gridsquare(grid_uuid: str, gridsquare: GridSquareCreateReq
     """Create a new grid square for a specific grid"""
 
     gridsquare_data = {
+        **gridsquare.model_dump(),
         "uuid": gridsquare.uuid,
         "grid_uuid": grid_uuid,
         "status": GridSquareStatus.NONE,
-        **gridsquare.model_dump(),
     }
     db_gridsquare = GridSquare(**gridsquare_data)
     db.add(db_gridsquare)
@@ -991,15 +991,11 @@ async def create_grid_gridsquare(grid_uuid: str, gridsquare: GridSquareCreateReq
         logger.error(f"Failed to publish gridsquare created event for UUID: {db_gridsquare.uuid}")
 
     response_data = {
+        **gridsquare.model_dump(),
         "uuid": gridsquare.uuid,
         "grid_uuid": grid_uuid,
         "status": GridSquareStatus.NONE,
-        **gridsquare.model_dump(),
     }
-
-    # Make sure status is set correctly (the above might get overridden by model_dump)
-    if "status" not in response_data or response_data["status"] is None:
-        response_data["status"] = GridSquareStatus.NONE
 
     return GridSquareResponse(**response_data)
 
@@ -1419,10 +1415,10 @@ async def create_foilhole_micrograph(
     """Create a new micrograph for a specific foil hole"""
 
     micrograph_data = {
+        **micrograph.model_dump(),
         "uuid": micrograph.uuid,
         "foilhole_uuid": foilhole_uuid,
         "status": MicrographStatus.NONE,
-        **micrograph.model_dump(),
     }
     db_micrograph = Micrograph(**micrograph_data)
     db.add(db_micrograph)
@@ -1438,16 +1434,12 @@ async def create_foilhole_micrograph(
         logger.error(f"Failed to publish micrograph created event for UUID: {db_micrograph.uuid}")
 
     response_data = {
+        **micrograph.model_dump(),
         "uuid": micrograph.uuid,
         "foilhole_uuid": foilhole_uuid,
         "foilhole_id": micrograph.foilhole_id,
         "status": MicrographStatus.NONE,
-        **micrograph.model_dump(),
     }
-
-    # Make sure status is set correctly (the above might get overridden by model_dump)
-    if "status" not in response_data or response_data["status"] is None:
-        response_data["status"] = MicrographStatus.NONE
 
     return MicrographResponse(**response_data)
 

--- a/tests/smartem_backend/test_gridsquares.py
+++ b/tests/smartem_backend/test_gridsquares.py
@@ -47,7 +47,7 @@ class TestUpdateGridSquare:
         )
         calls = stub_publisher("publish_gridsquare_updated")
 
-        resp = client.put("/gridsquares/gs-1", json={"defocus": 1.5, "status": "none"})
+        resp = client.put("/gridsquares/gs-1", json={"defocus": 1.5})
         assert resp.status_code == 200
         client._db.commit.assert_called_once()
         assert calls == [{"uuid": "gs-1", "grid_uuid": "grid-1", "gridsquare_id": "gs-id-1"}]
@@ -62,7 +62,7 @@ class TestUpdateGridSquare:
         regular = stub_publisher("publish_gridsquare_updated")
         lowmag = stub_publisher("publish_gridsquare_lowmag_updated")
 
-        resp = client.put("/gridsquares/gs-1", json={"lowmag": True, "defocus": 1.0, "status": "none"})
+        resp = client.put("/gridsquares/gs-1", json={"lowmag": True, "defocus": 1.0})
         assert resp.status_code == 200
         assert regular == []
         assert lowmag == [{"uuid": "gs-1", "grid_uuid": "grid-1", "gridsquare_id": "gs-id-1"}]
@@ -70,7 +70,7 @@ class TestUpdateGridSquare:
     def test_404_when_not_found(self, client, stub_publisher):
         set_db_row(client, None)
         calls = stub_publisher("publish_gridsquare_updated")
-        resp = client.put("/gridsquares/missing", json={"defocus": 1.0, "status": "none"})
+        resp = client.put("/gridsquares/missing", json={"defocus": 1.0})
         assert resp.status_code == 404
         assert calls == []
 
@@ -132,6 +132,15 @@ class TestCreateGridGridSquare:
         assert resp.status_code == 422
         client._db.add.assert_not_called()
         assert calls == []
+
+    def test_path_grid_uuid_wins_over_body(self, client, stub_publisher):
+        calls = stub_publisher("publish_gridsquare_created")
+        payload = _gs_payload(grid_uuid="other-grid")
+
+        resp = client.post("/grids/grid-1/gridsquares", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["grid_uuid"] == "grid-1"
+        assert calls[0]["grid_uuid"] == "grid-1"
 
 
 class TestGridSquareRegistered:

--- a/tests/smartem_backend/test_micrographs.py
+++ b/tests/smartem_backend/test_micrographs.py
@@ -3,12 +3,11 @@
 from .conftest import set_db_row
 
 
-def _micrograph_payload(uuid: str = "mic-1", foilhole_uuid: str = "fh-1", **overrides) -> dict:
+def _micrograph_payload(uuid: str = "mic-1", **overrides) -> dict:
     base = {
         "uuid": uuid,
         "micrograph_id": "mic-id-1",
         "foilhole_id": "fh-id-1",
-        "foilhole_uuid": foilhole_uuid,
     }
     base.update(overrides)
     return base
@@ -116,3 +115,12 @@ class TestCreateFoilHoleMicrograph:
         assert resp.status_code == 422
         client._db.add.assert_not_called()
         assert calls == []
+
+    def test_path_foilhole_uuid_wins_over_body(self, client, stub_publisher):
+        calls = stub_publisher("publish_micrograph_created")
+        payload = _micrograph_payload(foilhole_uuid="other-fh")
+
+        resp = client.post("/foilholes/fh-1/micrographs", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["foilhole_uuid"] == "fh-1"
+        assert calls[0]["foilhole_uuid"] == "fh-1"


### PR DESCRIPTION
## Summary

Two related endpoint bugs found while writing TestClient coverage in #277.

- **#278** (\`PUT /gridsquares/{uuid}\`): the handler accessed \`update_data[\"status\"]\` directly, so an update body without a \`status\` key (e.g. \`{\"defocus\": 1.5}\`) raised \`KeyError\` and returned 500. Fixed by switching to \`update_data.get()\` with the existing default.
- **#279** (\`POST /foilholes/{uuid}/micrographs\` + \`POST /grids/{uuid}/gridsquares\`): both endpoints built their persistence and response dicts as \`{explicit-keys, **request.model_dump()}\`, so the request body (with nullable defaults from the base model) shadowed path-derived UUIDs and the explicit \`status\`. Reordered to \`{**request.model_dump(), explicit-keys}\` so path parameters and the explicit status are authoritative, matching the documented behaviour.

Also drops the test workarounds added in #277 that were dodging these bugs, and adds two new regression tests asserting that path UUIDs win over conflicting body values.

Closes #278.
Closes #279.

## Test plan

- [x] \`uv run pytest tests/smartem_backend/\` - 184/184 pass (was 182, +2 regression tests)
- [x] \`uv run pre-commit run --files <changed>\` clean
- [x] Existing \`test_gridsquares.py\` and \`test_micrographs.py\` cases now run without the previous status / foilhole_uuid workarounds