### PR TITLE
fix: use // separator for nested Renovate preset path (#260)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>DiamondLightSource/smartem-devtools:renovate/default"],
+  "extends": ["github>DiamondLightSource/smartem-devtools//renovate/default"],
   "packageRules": [
     {
       "description": "Group Python deps",


### PR DESCRIPTION
## Summary

Renovate's preset reference syntax uses \`:\` for **named sub-presets** within a single config file and \`//\` for **nested file paths**. Our shared preset lives at \`renovate/default.json\` in \`smartem-devtools\`, so the correct reference is:

\`\`\`
github>DiamondLightSource/smartem-devtools//renovate/default
\`\`\`

The previous \`github>...:renovate/default\` form has been failing preset resolution since 2026-04-16, which is why Renovate raised #260 (\"Action Required: Fix Renovate Configuration\") and stopped opening PRs.

Closes #260.

## How I diagnosed it

\`renovate-config-validator\` against the schema passes - the config looks well-formed. The actual error only surfaces at preset resolution time, in a real Renovate run:

\`\`\`
$ docker run --rm -e RENOVATE_TOKEN=... renovate/renovate:slim renovate --autodiscover=false --dry-run=full DiamondLightSource/smartem-decisions

ERROR: Cannot find preset's package
       \"preset\": \"github>DiamondLightSource/smartem-devtools:renovate/default\"
       \"message\": \"preset not found\"
INFO:  Throwing preset error
       \"validationError\": \"Preset name not found within published preset config (github>DiamondLightSource/smartem-devtools:renovate/default)\"
INFO:  Repository has invalid config
\`\`\`

After flipping \`:\` to \`//\` and re-running, the config resolves cleanly and the dry-run proceeds normally.

## Side note

The same pattern (\`extends: [\"github>...:renovate/default\"]\`) is in smartem-devtools' own \`renovate.json\`, and presumably affects every other DLS repo that adopted this preset reference. Worth a follow-up sweep / PR there once this lands.

## Test plan

- [x] \`renovate-config-validator\` passes
- [x] Renovate dry-run reproduced the failure on the old form, succeeded on the new form
- [ ] Wait for Renovate to next run after merge - expect #260 to auto-close and the dependency dashboard to come back