### PR TITLE
chore(deps): bump mako 1.3.11 -> 1.3.12 (CVE-2026-44307)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -543,14 +543,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `mako` 1.3.11 → 1.3.12 in `uv.lock` to clear [code scanning alert #20](https://github.com/DiamondLightSource/smartem-decisions/security/code-scanning/20) (CVE-2026-44307, GHSA-2h4p-vjrc-8xpq).
- Mako is a transitive dependency via `alembic`. The vulnerability is a Windows-only path traversal in `TemplateLookup` that requires user-controlled template URIs — alembic renders migration scaffolding from package-internal paths, so we are not exploitable. Bump is purely to silence the scanner.
- Lockfile-only change (3 lines).

## Test plan
- [x] `uv lock --upgrade-package mako` resolves cleanly
- [x] `uv sync --extra backend` succeeds
- [x] `import mako, alembic` in the synced env reports mako 1.3.12 / alembic 1.17.2
- [x] CI passes