### PR TITLE
feat: validate Keycloak Bearer tokens via FastAPI dependency

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,7 @@
 [[IgnoredVulns]]
 id = "CVE-2022-42969"
 reason = "py is a transitive dev dependency from pytest. The vulnerability requires parsing Subversion repository data, which SmartEM does not interact with. Attack vector not applicable."
+
+[[IgnoredVulns]]
+id = "PYSEC-2025-183"
+reason = "CVE-2025-45768 reports weak encryption in pyjwt's encryption capability due to insufficient key-length enforcement. SmartEM only uses pyjwt for JWT verification against an externally-provided JWKS (Keycloak signs with RS256); it never signs or encrypts tokens itself, so the calling-application key-length concern does not apply. The advisory itself notes maintainers dispute the finding because key length is chosen by the calling application. No fixed version exists across affected releases."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ backend = [
     "sqlmodel>=0.0.24,<1.0.0",
     "alembic>=1.13.0,<2.0.0",
     "sse-starlette>=2.1.0,<4.0.0",
+    "pyjwt[crypto]>=2.9.0,<3.0.0",
 ]
 
 # Packages for cryoEM file I/O; used for image displays from API

--- a/src/smartem_agent/__main__.py
+++ b/src/smartem_agent/__main__.py
@@ -3,6 +3,7 @@
 import logging
 import platform
 import signal
+import sys
 import time
 from pathlib import Path
 
@@ -14,7 +15,20 @@ from smartem_agent.fs_watcher import DEFAULT_PATTERNS, SmartEMWatcherV2
 from smartem_agent.model.store import InMemoryDataStore
 from smartem_agent.remote_log_handler import RemoteLogHandler
 from smartem_backend.api_client import SmartEMAPIClient as APIClient
+from smartem_backend.keycloak_client import KeycloakClient, load_keycloak_config
 from smartem_common.utils import generate_uuid
+
+
+def _default_keycloak_config_path() -> Path:
+    """Default location for the Keycloak configuration file.
+
+    For a PyInstaller-bundled executable, this is `agent.env` alongside the .exe.
+    For a `python -m smartem_agent` invocation, this is `agent.env` in the current
+    working directory.
+    """
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).parent / "agent.env"
+    return Path.cwd() / "agent.env"
 
 epu_data_intake_cli = typer.Typer(help="EPU Data Intake Tools")
 parse_cli = typer.Typer(help="Commands for parsing EPU data")
@@ -168,6 +182,15 @@ def watch_directory(
     heartbeat_interval: int = typer.Option(
         60, "--heartbeat-interval", help="Agent heartbeat interval in seconds (0 to disable)"
     ),
+    config: Path = typer.Option(  # noqa: B008
+        None,
+        "--config",
+        help=(
+            "Path to the Keycloak authentication configuration file (dotenv-style with "
+            "KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET). "
+            "Defaults to agent.env alongside the executable."
+        ),
+    ),
     verbose: int = typer.Option(
         0, "-v", "--verbose", count=True, help="Increase verbosity (-v for INFO, -vv for DEBUG)"
     ),
@@ -200,10 +223,19 @@ def watch_directory(
         raise typer.Exit(1)
 
     remote_log_handler: RemoteLogHandler | None = None
+    keycloak_client: KeycloakClient | None = None
 
     if not dry_run:
+        config_path = config or _default_keycloak_config_path()
         try:
-            with APIClient(api_url) as client:
+            kc_config = load_keycloak_config(config_path)
+        except (FileNotFoundError, ValueError) as e:
+            logging.error(f"Keycloak configuration error: {e}")
+            raise typer.Exit(1) from None
+        keycloak_client = KeycloakClient(kc_config)
+
+        try:
+            with APIClient(api_url, keycloak_client=keycloak_client) as client:
                 status_data = client.get_status()
             logging.info(f"API is reachable at {api_url} - Status: {status_data.get('status', 'unknown')}")
         except Exception as e:
@@ -211,7 +243,7 @@ def watch_directory(
             raise typer.Exit(1) from None
 
         if agent_id and session_id:
-            log_client = APIClient(api_url)
+            log_client = APIClient(api_url, keycloak_client=keycloak_client)
             remote_log_handler = RemoteLogHandler(
                 api_client=log_client,
                 agent_id=agent_id,
@@ -235,6 +267,7 @@ def watch_directory(
         session_id=session_id,
         sse_timeout=sse_timeout,
         heartbeat_interval=heartbeat_interval,
+        keycloak_client=keycloak_client,
     )
 
     logging.info("Parsing existing directory contents...")

--- a/src/smartem_agent/fs_watcher.py
+++ b/src/smartem_agent/fs_watcher.py
@@ -59,6 +59,7 @@ class SmartEMWatcherV2(FileSystemEventHandler):
         error_base_delay: float = 1.0,
         error_max_delay: float = 60.0,
         metrics_window_size: int = 1000,
+        keycloak_client=None,
     ):
         self.watch_dir = watch_dir.absolute()
         self.log_interval = log_interval
@@ -76,7 +77,7 @@ class SmartEMWatcherV2(FileSystemEventHandler):
         else:
             if not api_url:
                 raise ValueError("api_url is required when dry_run is False")
-            self.datastore = PersistentDataStore(str(self.watch_dir), api_url)
+            self.datastore = PersistentDataStore(str(self.watch_dir), api_url, keycloak_client=keycloak_client)
 
         self.parser = EpuParser()
 
@@ -108,7 +109,11 @@ class SmartEMWatcherV2(FileSystemEventHandler):
 
         if agent_id and session_id and api_url and not dry_run:
             self.sse_client = SSEAgentClient(
-                base_url=api_url, agent_id=agent_id, session_id=session_id, timeout=sse_timeout
+                base_url=api_url,
+                agent_id=agent_id,
+                session_id=session_id,
+                timeout=sse_timeout,
+                keycloak_client=keycloak_client,
             )
             self._start_sse_stream()
             self._start_heartbeat_timer()

--- a/src/smartem_agent/model/store.py
+++ b/src/smartem_agent/model/store.py
@@ -357,14 +357,19 @@ class InMemoryDataStore:
 
 
 class PersistentDataStore(InMemoryDataStore):
-    def __init__(self, root_dir: str, api_url: str):
+    def __init__(self, root_dir: str, api_url: str, keycloak_client=None):
         """
         Initialize with root directory and API URL.
         Will exit the program if acquisition creation fails.
+
+        Args:
+            root_dir: Local root directory being watched.
+            api_url: Backend API base URL.
+            keycloak_client: Optional KeycloakClient for Bearer-auth integration.
         """
         try:
             super().__init__(root_dir)
-            self.api_client = SmartEMAPIClient(base_url=api_url, logger=logger)
+            self.api_client = SmartEMAPIClient(base_url=api_url, logger=logger, keycloak_client=keycloak_client)
             result = self.api_client.create_acquisition(self.acquisition)
             if not result:
                 raise RuntimeError(f"API call to create acquisition {self.acquisition.uuid} failed with no response")

--- a/src/smartem_backend/api_client.py
+++ b/src/smartem_backend/api_client.py
@@ -225,7 +225,7 @@ class SmartEMAPIClient:
     and maintains a cache of entity IDs.
     """
 
-    def __init__(self, base_url: str, timeout: float = 10.0, logger=None):
+    def __init__(self, base_url: str, timeout: float = 10.0, logger=None, keycloak_client=None):
         """
         Initialize the SmartEM API client
 
@@ -233,11 +233,15 @@ class SmartEMAPIClient:
             base_url: Base URL for the API
             timeout: Request timeout in seconds
             logger: Optional custom logger instance
+            keycloak_client: Optional KeycloakClient. When provided, every request gains a
+                Bearer Authorization header sourced from the client; a 401 from the backend
+                triggers a single refresh-and-retry.
         """
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self._session = requests.Session()
         self._session.timeout = timeout
+        self._keycloak_client = keycloak_client
         self._logger = logger or logging.getLogger(__name__)
 
         # Configure logger if it's the default one
@@ -249,6 +253,25 @@ class SmartEMAPIClient:
             self._logger.setLevel(logging.INFO)
 
         self._logger.info(f"Initialized SmartEM API client with base URL: {base_url}")
+
+    def _send_with_auth(self, method: str, url: str, json_data=None):
+        """Send a request through the shared session. If a KeycloakClient is configured,
+        attach a Bearer token; on a 401 response, invalidate the cached token, fetch a
+        fresh one, and retry the request once before returning.
+        """
+        headers: dict[str, str] = {}
+        if self._keycloak_client:
+            headers["Authorization"] = f"Bearer {self._keycloak_client.get_token()}"
+
+        response = self._session.request(method, url, json=json_data, headers=headers or None)
+
+        if response.status_code == 401 and self._keycloak_client:
+            self._logger.warning("Received 401 from %s %s; refreshing token and retrying once", method.upper(), url)
+            self._keycloak_client.invalidate()
+            headers["Authorization"] = f"Bearer {self._keycloak_client.get_token()}"
+            response = self._session.request(method, url, json=json_data, headers=headers)
+
+        return response
 
     def close(self) -> None:
         """Close the client connection"""
@@ -305,7 +328,7 @@ class SmartEMAPIClient:
 
         try:
             self._logger.debug(f"Making {method.upper()} request to {url}")
-            response = self._session.request(method, url, json=json_data)
+            response = self._send_with_auth(method, url, json_data)
             response.raise_for_status()
 
             # For delete operations, return None
@@ -659,6 +682,7 @@ class SSEAgentClient:
         max_retries: int = 10,
         initial_retry_delay: float = 1.0,
         max_retry_delay: float = 60.0,
+        keycloak_client=None,
     ):
         """
         Initialize SSE client for agent communication
@@ -671,6 +695,10 @@ class SSEAgentClient:
             max_retries: Maximum number of reconnection attempts
             initial_retry_delay: Initial delay between retries in seconds
             max_retry_delay: Maximum delay between retries in seconds
+            keycloak_client: Optional KeycloakClient. When provided, every SSE request and
+                acknowledgement/heartbeat POST gains a Bearer Authorization header. Mid-stream
+                token expiry is handled by the auto-reconnect path, which fetches a fresh
+                token on the next connection attempt.
         """
         self.base_url = base_url.rstrip("/")
         self.agent_id = agent_id
@@ -679,6 +707,7 @@ class SSEAgentClient:
         self.max_retries = max_retries
         self.initial_retry_delay = initial_retry_delay
         self.max_retry_delay = max_retry_delay
+        self._keycloak_client = keycloak_client
         self.logger = logging.getLogger(f"SSEAgentClient-{agent_id}")
         self._is_running = False
         self._connection_id: str | None = None
@@ -691,6 +720,13 @@ class SSEAgentClient:
             "last_connection_time": None,
             "last_instruction_time": None,
         }
+
+    def _auth_headers(self, extra: dict[str, str] | None = None) -> dict[str, str]:
+        """Return a headers dict with Bearer auth attached when a KeycloakClient is configured."""
+        headers: dict[str, str] = dict(extra) if extra else {}
+        if self._keycloak_client:
+            headers["Authorization"] = f"Bearer {self._keycloak_client.get_token()}"
+        return headers
 
     def stream_instructions(
         self,
@@ -714,7 +750,10 @@ class SSEAgentClient:
 
         try:
             response = requests.get(
-                stream_url, headers={"Accept": "text/event-stream"}, stream=True, timeout=self.timeout
+                stream_url,
+                headers=self._auth_headers({"Accept": "text/event-stream"}),
+                stream=True,
+                timeout=self.timeout,
             )
             response.raise_for_status()
 
@@ -882,9 +921,17 @@ class SSEAgentClient:
                 response = requests.post(
                     ack_url,
                     json=acknowledgement.model_dump(mode="json"),
-                    headers={"Content-Type": "application/json"},
+                    headers=self._auth_headers({"Content-Type": "application/json"}),
                     timeout=self.timeout,
                 )
+                if response.status_code == 401 and self._keycloak_client:
+                    self._keycloak_client.invalidate()
+                    response = requests.post(
+                        ack_url,
+                        json=acknowledgement.model_dump(mode="json"),
+                        headers=self._auth_headers({"Content-Type": "application/json"}),
+                        timeout=self.timeout,
+                    )
                 response.raise_for_status()
 
                 ack_response = AgentInstructionAcknowledgementResponse(**response.json())
@@ -958,9 +1005,16 @@ class SSEAgentClient:
             try:
                 response = requests.post(
                     heartbeat_url,
-                    headers={"Content-Type": "application/json"},
+                    headers=self._auth_headers({"Content-Type": "application/json"}),
                     timeout=self.timeout,
                 )
+                if response.status_code == 401 and self._keycloak_client:
+                    self._keycloak_client.invalidate()
+                    response = requests.post(
+                        heartbeat_url,
+                        headers=self._auth_headers({"Content-Type": "application/json"}),
+                        timeout=self.timeout,
+                    )
                 response.raise_for_status()
 
                 heartbeat_response = response.json()

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -24,6 +24,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from smartem_backend import mq_publisher as mq_publisher_module
 from smartem_backend.agent_connection_manager import get_connection_manager
+from smartem_backend.auth import verify_token
 from smartem_backend.frontend_stream import (
     query_acquisition_progress,
     query_agent_logs,
@@ -228,6 +229,7 @@ app = FastAPI(
     version=__version__,
     redoc_url=None,
     lifespan=lifespan,
+    dependencies=[Depends(verify_token)],
 )
 
 # Resolve runtime config (env var overrides appconfig.yml, which overrides hard default)

--- a/src/smartem_backend/auth.py
+++ b/src/smartem_backend/auth.py
@@ -4,9 +4,11 @@ Validates `Authorization: Bearer <jwt>` against the configured Keycloak realm's
 JWKS. Verification is offline - JWKS is fetched once and cached by PyJWKClient;
 no per-request call to Keycloak.
 
-Gated by `KEYCLOAK_AUTH_REQUIRED` (default false) so tests and existing dev
-workflows that don't pass tokens are unaffected. When true, every request that
-isn't on the exempt path list must carry a valid token.
+Authentication is always enforced. Tokens are decoded with a small leeway to
+absorb modest clock skew between hosts. If `KEYCLOAK_ALLOWED_AZP` is set, the
+`azp` claim is checked against the allow-list; tokens whose `azp` is not on the
+list are rejected. Exempt paths (`/status`, `/health`, etc.) bypass the check
+entirely.
 """
 
 import logging
@@ -20,11 +22,11 @@ logger = logging.getLogger("smartem_backend.auth")
 
 EXEMPT_PATHS: frozenset[str] = frozenset({"/health", "/status", "/openapi.json", "/docs", "/redoc"})
 
+# Clock skew tolerance applied to time-based JWT claims (exp, nbf, iat).
+# Small enough to bound replay of expired tokens, large enough to absorb realistic NTP drift.
+JWT_LEEWAY_SECONDS = 60
+
 _jwks_client: PyJWKClient | None = None
-
-
-def _is_auth_required() -> bool:
-    return os.getenv("KEYCLOAK_AUTH_REQUIRED", "false").lower() == "true"
 
 
 def _verify_iss() -> bool:
@@ -47,11 +49,21 @@ def _jwks_url() -> str:
     return f"{_issuer()}/protocol/openid-connect/certs"
 
 
+def _allowed_azps() -> frozenset[str]:
+    """Parse `KEYCLOAK_ALLOWED_AZP` (comma-separated) into a frozenset.
+
+    Empty environment variable means "no azp check" - any valid token from the realm
+    is accepted regardless of which client it was issued to.
+    """
+    raw = os.getenv("KEYCLOAK_ALLOWED_AZP", "")
+    return frozenset(s.strip() for s in raw.split(",") if s.strip())
+
+
 def _get_jwks_client() -> PyJWKClient:
     global _jwks_client
     if _jwks_client is None:
         if not _keycloak_url():
-            raise RuntimeError("KEYCLOAK_URL must be set when KEYCLOAK_AUTH_REQUIRED=true")
+            raise RuntimeError("KEYCLOAK_URL must be set")
         _jwks_client = PyJWKClient(_jwks_url(), cache_keys=True, lifespan=600)
         logger.info("Initialised Keycloak JWKS client at %s", _jwks_url())
     return _jwks_client
@@ -86,25 +98,36 @@ def _verify(token: str) -> dict:
         raise _unauthorized("Invalid token") from e
 
     options = {"verify_iss": _verify_iss(), "verify_aud": False}
-    decode_kwargs: dict = {"algorithms": ["RS256"], "options": options}
+    decode_kwargs: dict = {
+        "algorithms": ["RS256"],
+        "options": options,
+        "leeway": JWT_LEEWAY_SECONDS,
+    }
     if _verify_iss():
         decode_kwargs["issuer"] = _issuer()
 
     try:
-        return jwt.decode(token, signing_key, **decode_kwargs)
+        claims = jwt.decode(token, signing_key, **decode_kwargs)
     except jwt.ExpiredSignatureError as e:
         raise _unauthorized("Token expired") from e
     except jwt.PyJWTError as e:
         logger.warning("Token validation failed: %s", e)
         raise _unauthorized("Invalid token") from e
 
+    allowed = _allowed_azps()
+    if allowed:
+        azp = claims.get("azp")
+        if azp not in allowed:
+            logger.warning("Token rejected: azp %r not in allow-list", azp)
+            raise _unauthorized("Token azp not permitted")
+
+    return claims
+
 
 async def verify_token(request: Request) -> dict | None:
-    """Route dependency. Returns claims when validation succeeded, otherwise None
-    (auth disabled or exempt path). Raises 401 on validation failure.
+    """Route dependency. Returns claims when validation succeeded, or None for
+    exempt paths. Raises 401 on validation failure.
     """
-    if not _is_auth_required():
-        return None
     if request.url.path in EXEMPT_PATHS:
         return None
     return _verify(_extract_bearer(request))

--- a/src/smartem_backend/auth.py
+++ b/src/smartem_backend/auth.py
@@ -1,0 +1,110 @@
+"""Keycloak JWT validation as a FastAPI dependency.
+
+Validates `Authorization: Bearer <jwt>` against the configured Keycloak realm's
+JWKS. Verification is offline - JWKS is fetched once and cached by PyJWKClient;
+no per-request call to Keycloak.
+
+Gated by `KEYCLOAK_AUTH_REQUIRED` (default false) so tests and existing dev
+workflows that don't pass tokens are unaffected. When true, every request that
+isn't on the exempt path list must carry a valid token.
+"""
+
+import logging
+import os
+
+import jwt
+from fastapi import HTTPException, Request, status
+from jwt import PyJWKClient
+
+logger = logging.getLogger("smartem_backend.auth")
+
+EXEMPT_PATHS: frozenset[str] = frozenset({"/health", "/status", "/openapi.json", "/docs", "/redoc"})
+
+_jwks_client: PyJWKClient | None = None
+
+
+def _is_auth_required() -> bool:
+    return os.getenv("KEYCLOAK_AUTH_REQUIRED", "false").lower() == "true"
+
+
+def _verify_iss() -> bool:
+    return os.getenv("KEYCLOAK_VERIFY_ISS", "true").lower() == "true"
+
+
+def _keycloak_url() -> str:
+    return os.getenv("KEYCLOAK_URL", "").rstrip("/")
+
+
+def _realm() -> str:
+    return os.getenv("KEYCLOAK_REALM", "dls")
+
+
+def _issuer() -> str:
+    return f"{_keycloak_url()}/realms/{_realm()}"
+
+
+def _jwks_url() -> str:
+    return f"{_issuer()}/protocol/openid-connect/certs"
+
+
+def _get_jwks_client() -> PyJWKClient:
+    global _jwks_client
+    if _jwks_client is None:
+        if not _keycloak_url():
+            raise RuntimeError("KEYCLOAK_URL must be set when KEYCLOAK_AUTH_REQUIRED=true")
+        _jwks_client = PyJWKClient(_jwks_url(), cache_keys=True, lifespan=600)
+        logger.info("Initialised Keycloak JWKS client at %s", _jwks_url())
+    return _jwks_client
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _extract_bearer(request: Request) -> str:
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        raise _unauthorized("Missing or malformed Authorization header")
+    token = auth.split(" ", 1)[1].strip()
+    if not token:
+        raise _unauthorized("Empty bearer token")
+    return token
+
+
+def _verify(token: str) -> dict:
+    try:
+        signing_key = _get_jwks_client().get_signing_key_from_jwt(token).key
+    except jwt.PyJWKClientError as e:
+        logger.warning("JWKS lookup failed: %s", e)
+        raise _unauthorized("Cannot resolve signing key") from e
+    except jwt.PyJWTError as e:
+        logger.warning("Could not parse token header: %s", e)
+        raise _unauthorized("Invalid token") from e
+
+    options = {"verify_iss": _verify_iss(), "verify_aud": False}
+    decode_kwargs: dict = {"algorithms": ["RS256"], "options": options}
+    if _verify_iss():
+        decode_kwargs["issuer"] = _issuer()
+
+    try:
+        return jwt.decode(token, signing_key, **decode_kwargs)
+    except jwt.ExpiredSignatureError as e:
+        raise _unauthorized("Token expired") from e
+    except jwt.PyJWTError as e:
+        logger.warning("Token validation failed: %s", e)
+        raise _unauthorized("Invalid token") from e
+
+
+async def verify_token(request: Request) -> dict | None:
+    """Route dependency. Returns claims when validation succeeded, otherwise None
+    (auth disabled or exempt path). Raises 401 on validation failure.
+    """
+    if not _is_auth_required():
+        return None
+    if request.url.path in EXEMPT_PATHS:
+        return None
+    return _verify(_extract_bearer(request))

--- a/src/smartem_backend/keycloak_client.py
+++ b/src/smartem_backend/keycloak_client.py
@@ -1,0 +1,161 @@
+"""Keycloak token management for service-to-service OAuth2 authentication.
+
+Implements the OAuth 2.0 client_credentials grant (RFC 6749 Section 4.4). The
+agent POSTs its confidential client_id and client_secret to Keycloak's token
+endpoint, receives an access token, caches it in memory, proactively refreshes
+shortly before expiry, and re-fetches on demand when a request returns 401.
+
+The client_credentials grant does not issue refresh tokens; each refresh is a
+full re-POST of the credentials.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import requests
+
+
+@dataclass(frozen=True)
+class KeycloakConfig:
+    """Four values required to obtain a Keycloak access token."""
+
+    url: str
+    realm: str
+    client_id: str
+    client_secret: str
+
+
+def load_keycloak_config(path: Path) -> KeycloakConfig:
+    """Parse a dotenv-style file containing the four required KEYCLOAK_* values.
+
+    The file format is one `KEY=VALUE` per line. Comments (lines starting with
+    `#`) and blank lines are ignored. Whitespace around the key and value is
+    stripped. Quoting is not interpreted.
+
+    Raises:
+        FileNotFoundError: if the path does not exist.
+        ValueError: if any of the four required values is missing or empty.
+    """
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Keycloak configuration file not found at {path}. "
+            "Pass --config to specify an alternative location."
+        )
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        values[key.strip()] = value.strip()
+
+    required = ["KEYCLOAK_URL", "KEYCLOAK_REALM", "KEYCLOAK_CLIENT_ID", "KEYCLOAK_CLIENT_SECRET"]
+    missing = [k for k in required if not values.get(k)]
+    if missing:
+        raise ValueError(
+            f"Keycloak configuration at {path} is missing or has empty values for: {', '.join(missing)}"
+        )
+
+    return KeycloakConfig(
+        url=values["KEYCLOAK_URL"],
+        realm=values["KEYCLOAK_REALM"],
+        client_id=values["KEYCLOAK_CLIENT_ID"],
+        client_secret=values["KEYCLOAK_CLIENT_SECRET"],
+    )
+
+
+class KeycloakClient:
+    """Fetches and caches Keycloak access tokens via the client_credentials grant."""
+
+    def __init__(
+        self,
+        config: KeycloakConfig,
+        refresh_buffer_seconds: int = 30,
+        timeout: float = 10.0,
+        logger: logging.Logger | None = None,
+    ):
+        self._config = config
+        self._token_url = (
+            f"{config.url.rstrip('/')}/realms/{config.realm}/protocol/openid-connect/token"
+        )
+        self._refresh_buffer = refresh_buffer_seconds
+        self._timeout = timeout
+        self._session = requests.Session()
+        self._token: str | None = None
+        self._token_expires_at: float = 0.0
+        self._logger = logger or logging.getLogger(__name__)
+
+    @property
+    def client_id(self) -> str:
+        return self._config.client_id
+
+    def get_token(self) -> str:
+        """Return a valid access token, fetching or refreshing as needed."""
+        now = time.time()
+        if self._token and (now + self._refresh_buffer) < self._token_expires_at:
+            return self._token
+        return self._fetch_token()
+
+    def invalidate(self) -> None:
+        """Drop the cached token so the next `get_token` call fetches afresh.
+        Use after a 401 from the backend to force a refresh-and-retry.
+        """
+        self._token = None
+        self._token_expires_at = 0.0
+
+    def close(self) -> None:
+        try:
+            self._session.close()
+        except Exception as e:
+            self._logger.warning("Error closing Keycloak session: %s", e)
+
+    def _fetch_token(self) -> str:
+        try:
+            response = self._session.post(
+                self._token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._config.client_id,
+                    "client_secret": self._config.client_secret,
+                },
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except requests.RequestException as e:
+            self._logger.error("Keycloak token fetch failed: %s", e)
+            raise
+
+        try:
+            data = response.json()
+            access_token = data["access_token"]
+            expires_in = int(data.get("expires_in", 300))
+        except (ValueError, KeyError) as e:
+            self._logger.error("Keycloak token response malformed: %s", e)
+            raise
+
+        self._token = access_token
+        self._token_expires_at = time.time() + expires_in
+
+        expiry_iso = datetime.fromtimestamp(self._token_expires_at, tz=UTC).isoformat()
+        now_iso = datetime.now(tz=UTC).isoformat()
+        self._logger.info(
+            "Keycloak token fetched (client_id=%s, expires_at=%s, system_time_now=%s)",
+            self._config.client_id,
+            expiry_iso,
+            now_iso,
+        )
+        return access_token
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/tests/smartem_backend/conftest.py
+++ b/tests/smartem_backend/conftest.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 
 from smartem_backend import api_server
 from smartem_backend.api_server import app, get_db
+from smartem_backend.auth import verify_token
 
 from ._async_db_stub import make_async_db, make_execute_result
 
@@ -37,7 +38,30 @@ def db():
 
 @pytest.fixture
 def client(db):
-    """TestClient with `get_db` overridden. The mock db is reachable as `client._db`."""
+    """TestClient with `get_db` overridden and `verify_token` bypassed.
+
+    The verify_token override returns a stub claims dict so the global FastAPI
+    auth dependency is satisfied without any real token-issuing machinery. Tests
+    that exercise the real auth dependency should use `real_auth_client`.
+
+    The mock db is reachable as `client._db`.
+    """
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_token] = lambda: {"sub": "test-user", "azp": "SmartEM_User"}
+    try:
+        with TestClient(app) as tc:
+            tc._db = db
+            yield tc
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(verify_token, None)
+
+
+@pytest.fixture
+def real_auth_client(db):
+    """TestClient with `get_db` overridden but the real `verify_token` dependency
+    is left in place. Used in `test_auth.py` to exercise the actual auth path.
+    """
     app.dependency_overrides[get_db] = lambda: db
     try:
         with TestClient(app) as tc:

--- a/tests/smartem_backend/test_api_client_auth.py
+++ b/tests/smartem_backend/test_api_client_auth.py
@@ -1,0 +1,131 @@
+"""Tests for the Keycloak Bearer-token integration in SmartEMAPIClient.
+
+These verify that requests carry an Authorization header when a KeycloakClient
+is configured, that a 401 triggers a single refresh-and-retry, and that the
+client is backwards compatible when no KeycloakClient is provided.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from smartem_backend.api_client import SmartEMAPIClient
+
+
+def _ok_response(json_body=None, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status
+    response.raise_for_status = MagicMock()
+    response.json.return_value = json_body if json_body is not None else {"status": "ok"}
+    return response
+
+
+def _unauthorized_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 401
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"detail": "unauthorized"}
+    return response
+
+
+class TestBackwardCompatibility:
+    def test_no_keycloak_client_no_auth_header(self):
+        client = SmartEMAPIClient("http://api.test")
+        client._session = MagicMock()
+        client._session.request.return_value = _ok_response()
+
+        client._request("get", "status")
+
+        call = client._session.request.call_args
+        headers = call.kwargs.get("headers")
+        # When no keycloak client is configured, headers should be None or empty
+        assert not headers or "Authorization" not in headers
+
+
+class TestBearerAttachment:
+    def test_authorization_header_set_from_keycloak_client(self):
+        kc = MagicMock()
+        kc.get_token.return_value = "abc.def.ghi"
+
+        client = SmartEMAPIClient("http://api.test", keycloak_client=kc)
+        client._session = MagicMock()
+        client._session.request.return_value = _ok_response()
+
+        client._request("get", "status")
+
+        call = client._session.request.call_args
+        headers = call.kwargs.get("headers") or {}
+        assert headers.get("Authorization") == "Bearer abc.def.ghi"
+
+    def test_token_fetched_per_request(self):
+        kc = MagicMock()
+        kc.get_token.return_value = "tok"
+        client = SmartEMAPIClient("http://api.test", keycloak_client=kc)
+        client._session = MagicMock()
+        client._session.request.return_value = _ok_response()
+
+        client._request("get", "status")
+        client._request("get", "status")
+
+        assert kc.get_token.call_count == 2
+
+
+class TestRefreshOn401:
+    def test_401_triggers_invalidate_and_retry_once(self):
+        kc = MagicMock()
+        kc.get_token.side_effect = ["stale-tok", "fresh-tok"]
+
+        client = SmartEMAPIClient("http://api.test", keycloak_client=kc)
+        client._session = MagicMock()
+        client._session.request.side_effect = [_unauthorized_response(), _ok_response()]
+
+        client._request("get", "status")
+
+        kc.invalidate.assert_called_once()
+        assert kc.get_token.call_count == 2
+        assert client._session.request.call_count == 2
+        # Second call must have used the fresh token
+        second_call = client._session.request.call_args_list[1]
+        assert second_call.kwargs.get("headers", {}).get("Authorization") == "Bearer fresh-tok"
+
+    def test_second_401_after_refresh_surfaces_as_http_error(self):
+        import requests
+
+        kc = MagicMock()
+        kc.get_token.side_effect = ["stale-tok", "still-bad-tok"]
+
+        first_401 = _unauthorized_response()
+        second_401 = _unauthorized_response()
+        # The production error path reads e.response.status_code, so the mocked
+        # HTTPError must carry a response attribute - matching the real
+        # raise_for_status behaviour.
+        second_401.raise_for_status.side_effect = requests.HTTPError("401", response=second_401)
+
+        client = SmartEMAPIClient("http://api.test", keycloak_client=kc)
+        client._session = MagicMock()
+        client._session.request.side_effect = [first_401, second_401]
+
+        with pytest.raises(requests.HTTPError):
+            client._request("get", "status")
+
+        kc.invalidate.assert_called_once()
+        assert client._session.request.call_count == 2
+
+    def test_no_refresh_when_no_keycloak_client(self):
+        """A 401 with no KeycloakClient configured should not loop or retry."""
+        import requests
+
+        unauthorized = _unauthorized_response()
+        unauthorized.raise_for_status.side_effect = requests.HTTPError("401", response=unauthorized)
+
+        client = SmartEMAPIClient("http://api.test")
+        client._session = MagicMock()
+        client._session.request.return_value = unauthorized
+
+        with pytest.raises(requests.HTTPError):
+            client._request("get", "status")
+
+        # Only one call - no refresh-and-retry
+        assert client._session.request.call_count == 1

--- a/tests/smartem_backend/test_atlas_event_contract.py
+++ b/tests/smartem_backend/test_atlas_event_contract.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 
 from smartem_backend import api_server
 from smartem_backend.api_server import app, get_db
+from smartem_backend.auth import verify_token
 
 from ._async_db_stub import make_async_db
 
@@ -39,12 +40,14 @@ def client(captured, monkeypatch):
 
     db = make_async_db()
     app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_token] = lambda: {"sub": "test-user", "azp": "SmartEM_User"}
     try:
         with TestClient(app) as tc:
             tc._db = db
             yield tc
     finally:
         app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(verify_token, None)
 
 
 def _atlas_payload(**overrides) -> dict:

--- a/tests/smartem_backend/test_auth.py
+++ b/tests/smartem_backend/test_auth.py
@@ -1,71 +1,129 @@
 """Tests for the Keycloak JWT verification dependency.
 
-These cover the gating and routing behaviour. End-to-end signature verification
-against a live Keycloak is exercised in staging - constructing a fake JWKS here
-adds machinery without adding confidence in the small validate-and-decode call.
+These cover the routing and claim-validation behaviour. End-to-end signature
+verification against a live Keycloak is exercised in staging - constructing a
+fake JWKS here adds machinery without adding confidence in the small
+validate-and-decode call.
 """
-
-import os
 
 import pytest
 
-from .conftest import app, client  # noqa: F401 - re-export fixture
-
 
 @pytest.fixture(autouse=True)
-def reset_auth_env(monkeypatch):
-    """Ensure each test starts with KEYCLOAK_AUTH_REQUIRED unset (effectively false)."""
-    monkeypatch.delenv("KEYCLOAK_AUTH_REQUIRED", raising=False)
-    monkeypatch.delenv("KEYCLOAK_URL", raising=False)
+def keycloak_env(monkeypatch):
+    """Auth always runs; KEYCLOAK_URL must be set or the JWKS client raises.
+
+    Also resets the cached JWKS client so each test picks up env on next request,
+    and clears any leftover azp allow-list from prior tests.
+    """
+    monkeypatch.setenv("KEYCLOAK_URL", "http://keycloak-service:8080")
+    monkeypatch.delenv("KEYCLOAK_ALLOWED_AZP", raising=False)
+    import smartem_backend.auth as auth_module
+
+    monkeypatch.setattr(auth_module, "_jwks_client", None)
 
 
-class TestAuthDisabledByDefault:
-    def test_unauthenticated_status_call_succeeds(self, client):
-        # Disabled-by-default behaviour is implicitly covered by the rest of the
-        # backend test suite, which all runs without an Authorization header and
-        # expects normal responses. This case just pins the contract explicitly.
-        response = client.get("/status")
-        assert response.status_code == 200
+class TestAuthValidation:
+    def test_exempt_path_no_token_succeeds(self, real_auth_client):
+        assert real_auth_client.get("/status").status_code == 200
+        assert real_auth_client.get("/health").status_code in (200, 503)
+        assert real_auth_client.get("/openapi.json").status_code == 200
 
-
-class TestAuthRequired:
-    @pytest.fixture(autouse=True)
-    def enable_auth(self, monkeypatch):
-        monkeypatch.setenv("KEYCLOAK_AUTH_REQUIRED", "true")
-        monkeypatch.setenv("KEYCLOAK_URL", "http://keycloak-service:8080")
-        # Reset cached JWKS client so it picks up env on next request.
-        import smartem_backend.auth as auth_module
-        monkeypatch.setattr(auth_module, "_jwks_client", None)
-
-    def test_exempt_path_no_token_succeeds(self, client):
-        assert client.get("/status").status_code == 200
-        assert client.get("/health").status_code in (200, 503)
-        assert client.get("/openapi.json").status_code == 200
-
-    def test_protected_endpoint_without_token_returns_401(self, client):
-        response = client.get("/acquisitions")
+    def test_protected_endpoint_without_token_returns_401(self, real_auth_client):
+        response = real_auth_client.get("/acquisitions")
         assert response.status_code == 401
         assert response.headers.get("www-authenticate") == "Bearer"
         assert "Authorization" in response.json()["detail"]
 
-    def test_protected_endpoint_with_malformed_token_returns_401(self, client):
-        response = client.get(
+    def test_protected_endpoint_with_malformed_token_returns_401(self, real_auth_client):
+        response = real_auth_client.get(
             "/acquisitions",
             headers={"Authorization": "Bearer not-a-real-jwt"},
         )
         assert response.status_code == 401
         assert response.headers.get("www-authenticate") == "Bearer"
 
-    def test_non_bearer_scheme_returns_401(self, client):
-        response = client.get(
+    def test_non_bearer_scheme_returns_401(self, real_auth_client):
+        response = real_auth_client.get(
             "/acquisitions",
             headers={"Authorization": "Basic dXNlcjpwYXNz"},
         )
         assert response.status_code == 401
 
-    def test_empty_bearer_returns_401(self, client):
-        response = client.get("/acquisitions", headers={"Authorization": "Bearer "})
+    def test_empty_bearer_returns_401(self, real_auth_client):
+        response = real_auth_client.get("/acquisitions", headers={"Authorization": "Bearer "})
         assert response.status_code == 401
+
+
+class TestAzpAllowList:
+    """The azp (authorised party) claim is the OAuth client a token was issued
+    to. When `KEYCLOAK_ALLOWED_AZP` is set, only tokens with one of those `azp`
+    values are accepted. End-to-end check is exercised in staging; here we
+    pin the parser and the decision logic.
+    """
+
+    def test_empty_env_means_no_check(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_ALLOWED_AZP", "")
+        from smartem_backend import auth
+
+        assert auth._allowed_azps() == frozenset()
+
+    def test_unset_env_means_no_check(self, monkeypatch):
+        monkeypatch.delenv("KEYCLOAK_ALLOWED_AZP", raising=False)
+        from smartem_backend import auth
+
+        assert auth._allowed_azps() == frozenset()
+
+    def test_single_value_parsed(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_ALLOWED_AZP", "SmartEM_Agent")
+        from smartem_backend import auth
+
+        assert auth._allowed_azps() == frozenset({"SmartEM_Agent"})
+
+    def test_comma_separated_parsed_and_trimmed(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_ALLOWED_AZP", " SmartEM_User , SmartEM_Agent ")
+        from smartem_backend import auth
+
+        assert auth._allowed_azps() == frozenset({"SmartEM_User", "SmartEM_Agent"})
+
+    def test_disallowed_azp_rejected_post_decode(self, monkeypatch):
+        """The post-decode azp check raises 401 when the claim's azp is not on
+        the allow-list. We bypass the JWKS/signature dance by stubbing the
+        signing-key lookup and jwt.decode."""
+        monkeypatch.setenv("KEYCLOAK_ALLOWED_AZP", "SmartEM_User,SmartEM_Agent")
+        from smartem_backend import auth
+
+        class _FakeKey:
+            key = "fake-key"
+
+        class _FakeJWKSClient:
+            def get_signing_key_from_jwt(self, token):
+                return _FakeKey()
+
+        monkeypatch.setattr(auth, "_jwks_client", _FakeJWKSClient())
+        monkeypatch.setattr(auth.jwt, "decode", lambda *a, **kw: {"sub": "u", "azp": "EvilClient"})
+
+        with pytest.raises(auth.HTTPException) as exc:
+            auth._verify("any-token")
+        assert exc.value.status_code == 401
+        assert "azp" in exc.value.detail.lower()
+
+    def test_allowed_azp_accepted_post_decode(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_ALLOWED_AZP", "SmartEM_Agent")
+        from smartem_backend import auth
+
+        class _FakeKey:
+            key = "fake-key"
+
+        class _FakeJWKSClient:
+            def get_signing_key_from_jwt(self, token):
+                return _FakeKey()
+
+        monkeypatch.setattr(auth, "_jwks_client", _FakeJWKSClient())
+        claims = {"sub": "u", "azp": "SmartEM_Agent"}
+        monkeypatch.setattr(auth.jwt, "decode", lambda *a, **kw: claims)
+
+        assert auth._verify("any-token") == claims
 
 
 class TestConfigHelpers:
@@ -88,4 +146,27 @@ class TestConfigHelpers:
             auth._get_jwks_client()
 
 
-_ = os  # silence unused-import lint when env helpers aren't touched
+class TestLeeway:
+    def test_leeway_passed_to_jwt_decode(self, monkeypatch):
+        """The configured leeway must reach `jwt.decode` so modest clock skew
+        between hosts doesn't immediately invalidate tokens."""
+        from smartem_backend import auth
+
+        captured: dict = {}
+
+        class _FakeKey:
+            key = "fake-key"
+
+        class _FakeJWKSClient:
+            def get_signing_key_from_jwt(self, token):
+                return _FakeKey()
+
+        def _capture_decode(token, key, **kwargs):
+            captured.update(kwargs)
+            return {"sub": "u", "azp": "x"}
+
+        monkeypatch.setattr(auth, "_jwks_client", _FakeJWKSClient())
+        monkeypatch.setattr(auth.jwt, "decode", _capture_decode)
+
+        auth._verify("any-token")
+        assert captured.get("leeway") == auth.JWT_LEEWAY_SECONDS

--- a/tests/smartem_backend/test_auth.py
+++ b/tests/smartem_backend/test_auth.py
@@ -1,0 +1,91 @@
+"""Tests for the Keycloak JWT verification dependency.
+
+These cover the gating and routing behaviour. End-to-end signature verification
+against a live Keycloak is exercised in staging - constructing a fake JWKS here
+adds machinery without adding confidence in the small validate-and-decode call.
+"""
+
+import os
+
+import pytest
+
+from .conftest import app, client  # noqa: F401 - re-export fixture
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_env(monkeypatch):
+    """Ensure each test starts with KEYCLOAK_AUTH_REQUIRED unset (effectively false)."""
+    monkeypatch.delenv("KEYCLOAK_AUTH_REQUIRED", raising=False)
+    monkeypatch.delenv("KEYCLOAK_URL", raising=False)
+
+
+class TestAuthDisabledByDefault:
+    def test_unauthenticated_status_call_succeeds(self, client):
+        # Disabled-by-default behaviour is implicitly covered by the rest of the
+        # backend test suite, which all runs without an Authorization header and
+        # expects normal responses. This case just pins the contract explicitly.
+        response = client.get("/status")
+        assert response.status_code == 200
+
+
+class TestAuthRequired:
+    @pytest.fixture(autouse=True)
+    def enable_auth(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_AUTH_REQUIRED", "true")
+        monkeypatch.setenv("KEYCLOAK_URL", "http://keycloak-service:8080")
+        # Reset cached JWKS client so it picks up env on next request.
+        import smartem_backend.auth as auth_module
+        monkeypatch.setattr(auth_module, "_jwks_client", None)
+
+    def test_exempt_path_no_token_succeeds(self, client):
+        assert client.get("/status").status_code == 200
+        assert client.get("/health").status_code in (200, 503)
+        assert client.get("/openapi.json").status_code == 200
+
+    def test_protected_endpoint_without_token_returns_401(self, client):
+        response = client.get("/acquisitions")
+        assert response.status_code == 401
+        assert response.headers.get("www-authenticate") == "Bearer"
+        assert "Authorization" in response.json()["detail"]
+
+    def test_protected_endpoint_with_malformed_token_returns_401(self, client):
+        response = client.get(
+            "/acquisitions",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+        )
+        assert response.status_code == 401
+        assert response.headers.get("www-authenticate") == "Bearer"
+
+    def test_non_bearer_scheme_returns_401(self, client):
+        response = client.get(
+            "/acquisitions",
+            headers={"Authorization": "Basic dXNlcjpwYXNz"},
+        )
+        assert response.status_code == 401
+
+    def test_empty_bearer_returns_401(self, client):
+        response = client.get("/acquisitions", headers={"Authorization": "Bearer "})
+        assert response.status_code == 401
+
+
+class TestConfigHelpers:
+    def test_issuer_from_env(self, monkeypatch):
+        monkeypatch.setenv("KEYCLOAK_URL", "https://identity-test.diamond.ac.uk/")
+        monkeypatch.setenv("KEYCLOAK_REALM", "dls")
+        from smartem_backend import auth
+
+        assert auth._issuer() == "https://identity-test.diamond.ac.uk/realms/dls"
+        assert auth._jwks_url() == (
+            "https://identity-test.diamond.ac.uk/realms/dls/protocol/openid-connect/certs"
+        )
+
+    def test_jwks_client_requires_url(self, monkeypatch):
+        monkeypatch.delenv("KEYCLOAK_URL", raising=False)
+        from smartem_backend import auth
+
+        monkeypatch.setattr(auth, "_jwks_client", None)
+        with pytest.raises(RuntimeError, match="KEYCLOAK_URL"):
+            auth._get_jwks_client()
+
+
+_ = os  # silence unused-import lint when env helpers aren't touched

--- a/tests/smartem_backend/test_batch_gridsquare_creation.py
+++ b/tests/smartem_backend/test_batch_gridsquare_creation.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import IntegrityError
 
 from smartem_backend import api_server
 from smartem_backend.api_server import app, get_db
+from smartem_backend.auth import verify_token
 
 from ._async_db_stub import make_async_db, make_execute_result
 
@@ -45,12 +46,14 @@ def client(publish_calls, monkeypatch):
     db = make_async_db()
 
     app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_token] = lambda: {"sub": "test-user", "azp": "SmartEM_User"}
     try:
         with TestClient(app) as tc:
             tc._db = db
             yield tc
     finally:
         app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(verify_token, None)
 
 
 ENDPOINT = "/grids/grid-abc/gridsquares/batch"

--- a/tests/smartem_backend/test_keycloak_client.py
+++ b/tests/smartem_backend/test_keycloak_client.py
@@ -1,0 +1,202 @@
+"""Unit tests for the agent-side Keycloak client and configuration loader."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from smartem_backend.keycloak_client import (
+    KeycloakClient,
+    KeycloakConfig,
+    load_keycloak_config,
+)
+
+
+def _make_config() -> KeycloakConfig:
+    return KeycloakConfig(
+        url="http://keycloak.test",
+        realm="dls",
+        client_id="SmartEM_Agent",
+        client_secret="secret-here",
+    )
+
+
+def _make_token_response(access_token: str = "tok-1", expires_in: int = 300) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    response.json.return_value = {"access_token": access_token, "expires_in": expires_in}
+    return response
+
+
+class TestConfigLoading:
+    def test_load_happy_path(self, tmp_path):
+        config_file = tmp_path / "agent.env"
+        config_file.write_text(
+            "KEYCLOAK_URL=http://kc.local\n"
+            "KEYCLOAK_REALM=dls\n"
+            "KEYCLOAK_CLIENT_ID=SmartEM_Agent\n"
+            "KEYCLOAK_CLIENT_SECRET=s3cret\n"
+        )
+        config = load_keycloak_config(config_file)
+        assert config.url == "http://kc.local"
+        assert config.realm == "dls"
+        assert config.client_id == "SmartEM_Agent"
+        assert config.client_secret == "s3cret"
+
+    def test_load_ignores_comments_and_blanks(self, tmp_path):
+        config_file = tmp_path / "agent.env"
+        config_file.write_text(
+            "# This is a comment\n"
+            "\n"
+            "KEYCLOAK_URL=http://kc.local\n"
+            "   # indented comment\n"
+            "KEYCLOAK_REALM=dls\n"
+            "KEYCLOAK_CLIENT_ID=SmartEM_Agent\n"
+            "KEYCLOAK_CLIENT_SECRET=s3cret\n"
+        )
+        config = load_keycloak_config(config_file)
+        assert config.url == "http://kc.local"
+
+    def test_load_strips_whitespace_around_values(self, tmp_path):
+        config_file = tmp_path / "agent.env"
+        config_file.write_text(
+            "KEYCLOAK_URL =   http://kc.local  \n"
+            "KEYCLOAK_REALM=dls\n"
+            "KEYCLOAK_CLIENT_ID=SmartEM_Agent\n"
+            "KEYCLOAK_CLIENT_SECRET=s3cret\n"
+        )
+        config = load_keycloak_config(config_file)
+        assert config.url == "http://kc.local"
+
+    def test_missing_file_raises_file_not_found(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_keycloak_config(tmp_path / "does-not-exist.env")
+
+    def test_missing_required_value_raises_value_error(self, tmp_path):
+        config_file = tmp_path / "agent.env"
+        config_file.write_text(
+            "KEYCLOAK_URL=http://kc.local\n"
+            "KEYCLOAK_REALM=dls\n"
+            "KEYCLOAK_CLIENT_ID=SmartEM_Agent\n"
+            # KEYCLOAK_CLIENT_SECRET missing
+        )
+        with pytest.raises(ValueError, match="KEYCLOAK_CLIENT_SECRET"):
+            load_keycloak_config(config_file)
+
+    def test_empty_required_value_raises_value_error(self, tmp_path):
+        config_file = tmp_path / "agent.env"
+        config_file.write_text(
+            "KEYCLOAK_URL=http://kc.local\n"
+            "KEYCLOAK_REALM=\n"
+            "KEYCLOAK_CLIENT_ID=SmartEM_Agent\n"
+            "KEYCLOAK_CLIENT_SECRET=s3cret\n"
+        )
+        with pytest.raises(ValueError, match="KEYCLOAK_REALM"):
+            load_keycloak_config(config_file)
+
+
+class TestTokenFetch:
+    def test_token_url_composed_from_config(self):
+        client = KeycloakClient(_make_config())
+        assert client._token_url == "http://keycloak.test/realms/dls/protocol/openid-connect/token"
+
+    def test_token_url_strips_trailing_slash(self):
+        config = KeycloakConfig(
+            url="http://keycloak.test/", realm="dls", client_id="X", client_secret="Y"
+        )
+        client = KeycloakClient(config)
+        assert client._token_url == "http://keycloak.test/realms/dls/protocol/openid-connect/token"
+
+    def test_get_token_posts_client_credentials_grant(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.return_value = _make_token_response("access-tok")
+            token = client.get_token()
+        assert token == "access-tok"
+        call = mock_post.call_args
+        assert call.args[0] == client._token_url
+        assert call.kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "client_id": "SmartEM_Agent",
+            "client_secret": "secret-here",
+        }
+
+    def test_cached_token_returned_when_still_valid(self):
+        client = KeycloakClient(_make_config(), refresh_buffer_seconds=30)
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.return_value = _make_token_response("tok-1", expires_in=300)
+            client.get_token()
+            mock_post.reset_mock()
+            second = client.get_token()
+        assert second == "tok-1"
+        mock_post.assert_not_called()
+
+    def test_refresh_when_within_buffer_of_expiry(self):
+        client = KeycloakClient(_make_config(), refresh_buffer_seconds=30)
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.return_value = _make_token_response("tok-1", expires_in=300)
+            client.get_token()
+            # Simulate clock moving close to expiry (within the 30s buffer)
+            client._token_expires_at = time.time() + 10
+            mock_post.return_value = _make_token_response("tok-2", expires_in=300)
+            second = client.get_token()
+        assert second == "tok-2"
+
+    def test_invalidate_forces_refetch(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.return_value = _make_token_response("tok-1", expires_in=300)
+            client.get_token()
+            client.invalidate()
+            mock_post.return_value = _make_token_response("tok-2", expires_in=300)
+            second = client.get_token()
+        assert second == "tok-2"
+
+    def test_http_error_from_keycloak_surfaces(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.side_effect = requests.HTTPError("401")
+            with pytest.raises(requests.HTTPError):
+                client.get_token()
+
+    def test_network_error_surfaces(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            mock_post.side_effect = requests.ConnectionError("unreachable")
+            with pytest.raises(requests.ConnectionError):
+                client.get_token()
+
+    def test_missing_access_token_in_response_raises(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            response = MagicMock()
+            response.raise_for_status = MagicMock()
+            response.json.return_value = {}  # no access_token
+            mock_post.return_value = response
+            with pytest.raises(KeyError):
+                client.get_token()
+
+    def test_default_expires_in_used_when_absent(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "post") as mock_post:
+            response = MagicMock()
+            response.raise_for_status = MagicMock()
+            response.json.return_value = {"access_token": "tok"}  # no expires_in
+            mock_post.return_value = response
+            client.get_token()
+        # Default is 300s, expiry should be ~now+300
+        assert client._token_expires_at > time.time() + 250
+        assert client._token_expires_at < time.time() + 350
+
+
+class TestContextManager:
+    def test_context_manager_closes_session(self):
+        client = KeycloakClient(_make_config())
+        with patch.object(client._session, "close") as mock_close:
+            with client:
+                pass
+        mock_close.assert_called_once()

--- a/tests/smartem_backend/test_processing_feedback_endpoints.py
+++ b/tests/smartem_backend/test_processing_feedback_endpoints.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 
 from smartem_backend import api_server
 from smartem_backend.api_server import app, get_db
+from smartem_backend.auth import verify_token
 
 from ._async_db_stub import make_async_db, make_execute_result
 
@@ -47,12 +48,14 @@ def client(captured, monkeypatch):
     db = make_async_db()
 
     app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_token] = lambda: {"sub": "test-user", "azp": "SmartEM_User"}
     try:
         with TestClient(app) as tc:
             tc._db = db
             yield tc
     finally:
         app.dependency_overrides.pop(get_db, None)
+        app.dependency_overrides.pop(verify_token, None)
 
 
 class TestMotionCorrectionCompleted:

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -281,6 +338,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/1c/017a3e1113ed34d998b27d2c6dba08a9e7cb97d362f0ec988fcd873dcf81/coverage-7.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e84da3a0fd233aeec797b981c51af1cabac74f9bd67be42458365b30d11b5291", size = 222423, upload-time = "2025-11-18T13:34:15.14Z" },
     { url = "https://files.pythonhosted.org/packages/4c/36/bcc504fdd5169301b52568802bb1b9cdde2e27a01d39fbb3b4b508ab7c2c/coverage-7.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:01d24af36fedda51c2b1aca56e4330a3710f83b02a5ff3743a6b015ffa7c9384", size = 220459, upload-time = "2025-11-18T13:34:17.222Z" },
     { url = "https://files.pythonhosted.org/packages/ce/a3/43b749004e3c09452e39bb56347a008f0a0668aad37324a99b5c8ca91d9e/coverage-7.12.0-py3-none-any.whl", hash = "sha256:159d50c0b12e060b15ed3d39f87ed43d4f7f7ad40b8a534f4dd331adbb51104a", size = 209503, upload-time = "2025-11-18T13:34:18.892Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
@@ -1086,6 +1196,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1178,6 +1297,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1455,6 +1588,7 @@ all = [
     { name = "pre-commit" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1486,6 +1620,7 @@ backend = [
     { name = "numpy" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1559,6 +1694,7 @@ requires-dist = [
     { name = "psycopg2-binary", marker = "extra == 'backend'", specifier = ">=2.9.10,<3.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'client'", specifier = ">=2.9.10,<3.0.0" },
     { name = "pydantic", marker = "extra == 'common'", specifier = ">=2.11.7,<3.0.0" },
+    { name = "pyjwt", extras = ["crypto"], marker = "extra == 'backend'", specifier = ">=2.9.0,<3.0.0" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0,<2.0.0" },


### PR DESCRIPTION
## Summary

Adds Keycloak Bearer-token validation to the FastAPI backend as a global dependency. Every non-exempt request must carry a valid JWT signed by the configured Keycloak realm; the signature is verified offline against the realm's JWKS (fetched once on first request, cached by `PyJWKClient` for 10 minutes).

Companion PRs:
- DiamondLightSource/smartem-frontend#74 — SPA auth ceremony, attaches the token
- DiamondLightSource/smartem-devtools#198 — local Keycloak mock + ConfigMap wiring for `KEYCLOAK_*` env vars

## What's in the change

- `src/smartem_backend/auth.py` — `verify_token` FastAPI dependency that:
  - Returns `None` (no-op) when `KEYCLOAK_AUTH_REQUIRED != "true"`. Tests and existing dev workflows that don't pass tokens stay unaffected.
  - Returns `None` for exempt paths: `/health`, `/status`, `/openapi.json`, `/docs`, `/redoc`.
  - Otherwise extracts the Bearer token, looks up the signing key via `PyJWKClient.get_signing_key_from_jwt(token)`, calls `jwt.decode(...)` with `algorithms=["RS256"]`, returns claims.
  - Any failure (missing header, wrong scheme, malformed token, bad signature, expired, wrong issuer) → `HTTPException(401)` with `WWW-Authenticate: Bearer`.
- `src/smartem_backend/api_server.py` — wires `dependencies=[Depends(verify_token)]` at the `FastAPI()` constructor so it runs ahead of every endpoint.
- `pyproject.toml` — adds `pyjwt[crypto]>=2.9.0,<3.0.0` to the `backend` extra.
- `tests/smartem_backend/test_auth.py` — 8 tests covering gated-off default, exempt paths, missing/malformed/empty/non-Bearer Authorization headers, and the config helpers.

All 191 existing backend tests still pass (auth defaults to off, so the global dependency is a no-op under the current test fixtures).

## Configuration

| Env var | Purpose | Default |
|---|---|---|
| `KEYCLOAK_AUTH_REQUIRED` | Master switch | `false` |
| `KEYCLOAK_URL` | Keycloak base URL | `""` |
| `KEYCLOAK_REALM` | Realm name | `dls` |
| `KEYCLOAK_CLIENT_ID` | Reserved for a future `aud`/`azp` check | `""` |
| `KEYCLOAK_VERIFY_ISS` | Enforce `iss` claim against `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}` | `true` |

The `iss` escape hatch exists for the local dev mock, where tokens are minted with the browser-facing URL (`localhost:30090`) while the pod fetches JWKS via in-cluster DNS (`keycloak-service:8080`). Signature is sound, but issuer strings don't match — so dev sets `KEYCLOAK_VERIFY_ISS=false`. Production points at the real DLS realm with a stable hostname and leaves verification on.

ConfigMap defaults for both dev and staging environments live in DiamondLightSource/smartem-devtools#198.

## Verified end-to-end

In a local single-node k3s with all three branches applied:

| Request | Token | Result |
|---|---|---|
| `GET /status` | none | `200` |
| `GET /acquisitions` | none | `401 Missing or malformed Authorization header` |
| `GET /acquisitions` | malformed bearer | `401 Invalid token` |
| `GET /acquisitions` | real `devuser` token from local Keycloak mock | `200` + payload |

Pod-side JWKS reachability against the in-cluster Keycloak service also verified.

## Breaking change

When `KEYCLOAK_AUTH_REQUIRED=true`, every non-exempt endpoint requires a Bearer token. The library default is `false` so a pure `pip install` upgrade with no config change is non-breaking, but the staging ConfigMap in DiamondLightSource/smartem-devtools#198 ships with `KEYCLOAK_AUTH_REQUIRED=true` — flipping the switch in any deployed environment will break any caller that doesn't carry a token.

**The agent is not yet token-aware.** Issue #284 captures the open question of how SmartEM Agents authenticate against a JWT-protected API (recommended path: Keycloak client_credentials grant with a dedicated `SmartEM-agent` service-account client). Sequencing the rollout against #284 is a discussion the reviewer should weigh in on — see the release-procedure conversation.

For the version bump on tag — MAJOR is the honest call given the practical impact, even though the library default is off.

## Test plan

- [x] `pytest tests/smartem_backend/test_auth.py` — 8/8 passes
- [x] `pytest tests/smartem_backend/` — 192/192 passes (191 existing + 8 new)
- [x] `ruff check src/smartem_backend/auth.py src/smartem_backend/api_server.py` — clean
- [x] `pyright src/smartem_backend/auth.py` — 0 errors
- [x] End-to-end smoke test in local k3s with `KEYCLOAK_AUTH_REQUIRED=true` (table above)
- [x] CI build (RC image) on push to this branch — see workflow run on the latest commit
