### PR TITLE
chore(osv): prune stale ignores

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,7 +1,8 @@
-[[IgnoredVulns]]
-id = "CVE-2022-42969"
-reason = "py is a transitive dev dependency from pytest. The vulnerability requires parsing Subversion repository data, which SmartEM does not interact with. Attack vector not applicable."
+# OSV Scanner configuration
+# https://google.github.io/osv-scanner/configuration/
 
-[[IgnoredVulns]]
-id = "PYSEC-2025-183"
-reason = "CVE-2025-45768 reports weak encryption in pyjwt's encryption capability due to insufficient key-length enforcement. SmartEM only uses pyjwt for JWT verification against an externally-provided JWKS (Keycloak signs with RS256); it never signs or encrypts tokens itself, so the calling-application key-length concern does not apply. The advisory itself notes maintainers dispute the finding because key length is chosen by the calling application. No fixed version exists across affected releases."
+# No exemptions configured yet
+# Add vulnerability exemptions here as needed:
+# [[IgnoredVulns]]
+# id = "GHSA-xxxx-xxxx-xxxx"
+# reason = "Not exploitable in our usage"


### PR DESCRIPTION
## Summary

Both entries in \`osv-scanner.toml\` are reported as \"unused ignores\" by every recent scan, meaning the underlying vulnerabilities are no longer detected against the current dependency tree:

- \`CVE-2022-42969\` (\`py\` library) — no longer present, likely dropped as a transitive of newer pytest releases.
- \`PYSEC-2025-183\` (\`pyjwt\` key-length advisory) — no longer flagged by OSV against the version in use, consistent with the maintainers' dispute of the affected range upstream.

Replace with the same placeholder template used by \`smartem-frontend/osv-scanner.toml\` so the file stays in place as the documented location for future exemptions.

If either advisory returns, the scanner will flag it again and the entry can be re-added with fresh rationale.

## Evidence

From the [scheduled scan on 2026-05-22 04:28 UTC](https://github.com/DiamondLightSource/smartem-decisions/actions/runs/26268419183):

\`\`\`
Loaded filter from: /github/workspace/osv-scanner.toml
/github/workspace/osv-scanner.toml has unused ignores:
 - CVE-2022-42969
 - PYSEC-2025-183
Exit code: 0
\`\`\`

## Test plan

- [x] \`pre-commit run --files osv-scanner.toml\` passes
- [x] PR \`scan-pr / osv-scan\` check still passes (validates the new config is well-formed and produces no findings)