### PR TITLE
security: upload gitleaks SARIF to code scanning

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yml
+++ b/.github/workflows/leaked-secrets-scan.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 3 * * *'  # Daily at 3 AM UTC (3-4 AM UK time)
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   gitleaks-licensed:
     name: gitleaks (licensed)
@@ -53,6 +57,13 @@ jobs:
 
       - name: Run gitleaks
         run: gitleaks detect --source . --redact -c .gitleaks.toml -v --report-format sarif --report-path gitleaks-report.sarif
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks-report.sarif
+          category: gitleaks
 
       - name: Upload report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The gitleaks CLI job writes a SARIF report but currently only attaches it as a workflow artifact, so findings never surface in the **Security → Code scanning** tab and cannot be triaged alongside the OSV scanner results.

## Changes

- Add a new step `Upload SARIF to code scanning` using `github/codeql-action/upload-sarif@v3` after the gitleaks run.
- Add a workflow-level `permissions` block granting `security-events: write` (required for SARIF upload) and `contents: read`.
- The existing `Upload report` artifact step is kept — useful for downloading the raw SARIF for offline inspection.

## Why both uploads

- **SARIF upload** → Security tab. Triageable, alertable, deduped across runs.
- **Artifact upload** → workflow run page. Browsable, downloadable, kept for 30 days.

They serve different audiences; happy to drop the artifact step if the team prefers a single source.

## Validation

- The licensed gitleaks job (gated on `GITLEAKS_LICENSE`) is unchanged — `gitleaks/gitleaks-action@v2` uploads to code scanning on its own and inherits the new workflow-level permissions.
- `if: always()` ensures the SARIF is uploaded even when gitleaks exits non‑zero on a finding, so the alert is visible in the Security tab.

## Test plan

- [ ] Confirm CI run succeeds and the new step appears in workflow logs.
- [ ] After merge, verify a gitleaks SARIF entry appears under Security → Code scanning (initially zero alerts is expected — current scans find no leaks).