### PR TITLE
chore: restore self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 4,16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: renovatebot/github-action@v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+          configurationFile: renovate.json

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,7 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Run against this repo only, using the auto-provided GITHUB_TOKEN (no PAT to manage).
+      # GITHUB_TOKEN can't autodiscover, so the target repo is set explicitly. Trade-off: PRs that
+      # Renovate opens with GITHUB_TOKEN do not trigger this repo's other workflows, so dependency
+      # PRs arrive without CI until manually re-run. Swap to a GitHub App token if that becomes a pain.
       - uses: renovatebot/github-action@v46.1.14
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
         with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           configurationFile: renovate.json


### PR DESCRIPTION
## Summary

Restores the self-hosted Renovate workflow that was dropped in smartem-devtools#182 on 2026-03-25 in favour of the org-wide Mend.io Renovate GitHub App. The app has not been reliably processing this repo since then — visible in git log as a sequence of manually-authored `chore(deps)` and `security:` CVE bumps over the past month (mako, urllib3, idna, starlette on smartem-decisions; equivalent gaps elsewhere) that Renovate should have automated.

## What this changes

Adds `.github/workflows/renovate.yml`:
- Twice-daily schedule (`04:00` and `16:00` UTC) plus `workflow_dispatch` for ad-hoc runs.
- Pins `renovatebot/github-action@v46.1.14` (latest as of 2026-05-11) — Renovate itself will bump it.
- `permissions` block covers what `GITHUB_TOKEN` needs for checkout and the action's bookkeeping; the actual Renovate identity and write permissions come from `RENOVATE_TOKEN`.
- Reads existing `renovate.json` (no config changes needed).

## What does NOT change

- `renovate.json` and the shared `renovate/default.json` preset are untouched — both validate cleanly via `renovate-config-validator`.
- The Mend.io org-wide app remains installed but will no-op once the self-hosted workflow is running.

## Required before merge

Repo admin must add a `RENOVATE_TOKEN` secret (fine-grained PAT with `contents: write`, `pull-requests: write`, `issues: write`, `workflows: write`, `metadata: read` on this repo). Without it the workflow will run but Renovate will exit immediately complaining about an empty token.

## Test plan

- [ ] `RENOVATE_TOKEN` secret added.
- [ ] Trigger the workflow manually via Actions → Renovate → Run workflow.
- [ ] Verify the run completes (visible in Actions tab; ~1-2 min).
- [ ] Verify the Dependency Dashboard issue gets refreshed (Renovate updates in place).
- [ ] Verify a real PR appears for at least one pending update from the dashboard's "Awaiting Schedule" list.

## Why per-repo and not autodiscovery

Per-repo workflow keeps the Renovate orchestration footprint inside each repo — no cross-repo token scope, no single workflow whose failure stops dep updates everywhere. Aligned with the workspace's preference for vendor-independent, locally-controlled tooling.