### PR TITLE
feat(api): publish canonical OpenAPI spec, add /version endpoint

### DIFF
--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -1,0 +1,64 @@
+name: Publish OpenAPI spec
+
+# Canonical OpenAPI spec publisher (ADR 0020). On pushes to main that touch the
+# backend, regenerate docs/api/openapi.json; if the API surface changed, commit
+# the refreshed spec and notify smartem-devtools so it can refresh its downstream
+# swagger caches and redeploy GitHub Pages.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/smartem_backend/**'
+      - 'src/smartem_common/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-openapi-spec
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra all
+
+      - name: Regenerate canonical spec
+        id: publish
+        run: uv run python tools/publish_openapi.py >> "$GITHUB_OUTPUT"
+
+      - name: Commit refreshed spec
+        if: steps.publish.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/api/openapi.json
+          git commit -m "chore(api): publish OpenAPI spec [skip ci]"
+          git push origin HEAD:main
+
+      - name: Notify smartem-devtools
+        if: steps.publish.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DEVTOOLS_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DEVTOOLS_DISPATCH_TOKEN not set - spec committed but smartem-devtools not notified."
+            exit 0
+          fi
+          gh api repos/DiamondLightSource/smartem-devtools/dispatches \
+            -f event_type=openapi-spec-updated

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,0 +1,8364 @@
+{
+  "components": {
+    "schemas": {
+      "AcquisitionCreateRequest": {
+        "properties": {
+          "atlas_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Path"
+          },
+          "clustering_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Mode"
+          },
+          "clustering_radius": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Radius"
+          },
+          "computer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "instrument_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Id"
+          },
+          "instrument_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid"
+        ],
+        "title": "AcquisitionCreateRequest",
+        "type": "object"
+      },
+      "AcquisitionGridCountResponse": {
+        "properties": {
+          "acquisition_uuid": {
+            "title": "Acquisition Uuid",
+            "type": "string"
+          },
+          "grids_completed": {
+            "title": "Grids Completed",
+            "type": "integer"
+          },
+          "grids_total": {
+            "title": "Grids Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "acquisition_uuid",
+          "grids_total",
+          "grids_completed"
+        ],
+        "title": "AcquisitionGridCountResponse",
+        "type": "object"
+      },
+      "AcquisitionResponse": {
+        "properties": {
+          "atlas_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Path"
+          },
+          "clustering_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Mode"
+          },
+          "clustering_radius": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Radius"
+          },
+          "computer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "instrument_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Id"
+          },
+          "instrument_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "name",
+          "status",
+          "start_time",
+          "end_time",
+          "paused_time",
+          "storage_path",
+          "atlas_path",
+          "clustering_mode",
+          "clustering_radius",
+          "instrument_model",
+          "instrument_id",
+          "computer_name"
+        ],
+        "title": "AcquisitionResponse",
+        "type": "object"
+      },
+      "AcquisitionStatus": {
+        "enum": [
+          "planned",
+          "started",
+          "completed",
+          "paused",
+          "abandoned"
+        ],
+        "title": "AcquisitionStatus",
+        "type": "string"
+      },
+      "AcquisitionUpdateRequest": {
+        "properties": {
+          "atlas_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Path"
+          },
+          "clustering_mode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Mode"
+          },
+          "clustering_radius": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clustering Radius"
+          },
+          "computer_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Computer Name"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "instrument_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Id"
+          },
+          "instrument_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instrument Model"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "paused_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Time"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AcquisitionStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "storage_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Path"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "AcquisitionUpdateRequest",
+        "type": "object"
+      },
+      "AgentInstructionAcknowledgement": {
+        "additionalProperties": false,
+        "description": "Request model for instruction acknowledgements from agents",
+        "properties": {
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "processed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processed At"
+          },
+          "processing_time_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Processing Time Ms"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "status": {
+            "enum": [
+              "received",
+              "processed",
+              "failed",
+              "declined"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "AgentInstructionAcknowledgement",
+        "type": "object"
+      },
+      "AgentInstructionAcknowledgementResponse": {
+        "description": "Response model for instruction acknowledgement confirmations",
+        "properties": {
+          "acknowledged_at": {
+            "title": "Acknowledged At",
+            "type": "string"
+          },
+          "agent_id": {
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "instruction_id": {
+            "title": "Instruction Id",
+            "type": "string"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "instruction_id",
+          "acknowledged_at",
+          "agent_id",
+          "session_id"
+        ],
+        "title": "AgentInstructionAcknowledgementResponse",
+        "type": "object"
+      },
+      "AgentLogBatchRequest": {
+        "properties": {
+          "logs": {
+            "items": {
+              "$ref": "#/components/schemas/AgentLogEntry"
+            },
+            "title": "Logs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "logs"
+        ],
+        "title": "AgentLogBatchRequest",
+        "type": "object"
+      },
+      "AgentLogBatchResponse": {
+        "properties": {
+          "stored": {
+            "title": "Stored",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "stored"
+        ],
+        "title": "AgentLogBatchResponse",
+        "type": "object"
+      },
+      "AgentLogEntry": {
+        "properties": {
+          "level": {
+            "title": "Level",
+            "type": "string"
+          },
+          "logger_name": {
+            "title": "Logger Name",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "timestamp",
+          "level",
+          "logger_name",
+          "message"
+        ],
+        "title": "AgentLogEntry",
+        "type": "object"
+      },
+      "AtlasCreateRequest": {
+        "properties": {
+          "acquisition_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Date"
+          },
+          "atlas_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Id"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
+          },
+          "tiles": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AtlasTileCreateRequest"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tiles"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "grid_uuid",
+          "name"
+        ],
+        "title": "AtlasCreateRequest",
+        "type": "object"
+      },
+      "AtlasResponse": {
+        "properties": {
+          "acquisition_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Date"
+          },
+          "atlas_id": {
+            "title": "Atlas Id",
+            "type": "string"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
+          },
+          "tiles": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": [],
+            "title": "Tiles"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "grid_uuid",
+          "atlas_id",
+          "acquisition_date",
+          "storage_folder",
+          "description",
+          "name"
+        ],
+        "title": "AtlasResponse",
+        "type": "object"
+      },
+      "AtlasTileCreateRequest": {
+        "properties": {
+          "atlas_uuid": {
+            "title": "Atlas Uuid",
+            "type": "string"
+          },
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
+          },
+          "position_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position X"
+          },
+          "position_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position Y"
+          },
+          "size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size X"
+          },
+          "size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Y"
+          },
+          "tile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tile Id"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "atlas_uuid"
+        ],
+        "title": "AtlasTileCreateRequest",
+        "type": "object"
+      },
+      "AtlasTileGridSquarePositionResponse": {
+        "properties": {
+          "atlastile_uuid": {
+            "title": "Atlastile Uuid",
+            "type": "string"
+          },
+          "center_x": {
+            "title": "Center X",
+            "type": "integer"
+          },
+          "center_y": {
+            "title": "Center Y",
+            "type": "integer"
+          },
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "size_height": {
+            "title": "Size Height",
+            "type": "integer"
+          },
+          "size_width": {
+            "title": "Size Width",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "atlastile_uuid",
+          "gridsquare_uuid",
+          "center_x",
+          "center_y",
+          "size_width",
+          "size_height"
+        ],
+        "title": "AtlasTileGridSquarePositionResponse",
+        "type": "object"
+      },
+      "AtlasTileResponse": {
+        "properties": {
+          "atlas_uuid": {
+            "title": "Atlas Uuid",
+            "type": "string"
+          },
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
+          },
+          "position_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position X"
+          },
+          "position_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position Y"
+          },
+          "size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size X"
+          },
+          "size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Y"
+          },
+          "tile_id": {
+            "title": "Tile Id",
+            "type": "string"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "atlas_uuid",
+          "tile_id",
+          "position_x",
+          "position_y",
+          "size_x",
+          "size_y",
+          "file_format",
+          "base_filename"
+        ],
+        "title": "AtlasTileResponse",
+        "type": "object"
+      },
+      "AtlasTileUpdateRequest": {
+        "properties": {
+          "atlas_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Uuid"
+          },
+          "base_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Filename"
+          },
+          "file_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Format"
+          },
+          "position_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position X"
+          },
+          "position_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position Y"
+          },
+          "size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size X"
+          },
+          "size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Y"
+          },
+          "tile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tile Id"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "AtlasTileUpdateRequest",
+        "type": "object"
+      },
+      "AtlasUpdateRequest": {
+        "properties": {
+          "acquisition_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Date"
+          },
+          "atlas_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Id"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "storage_folder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Folder"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "AtlasUpdateRequest",
+        "type": "object"
+      },
+      "CtfEstimationCompletedRequest": {
+        "properties": {
+          "ctf_max_res": {
+            "title": "Ctf Max Res",
+            "type": "number"
+          }
+        },
+        "required": [
+          "ctf_max_res"
+        ],
+        "title": "CtfEstimationCompletedRequest",
+        "type": "object"
+      },
+      "CtfEstimationRegisteredRequest": {
+        "properties": {
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "quality": {
+            "title": "Quality",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "quality"
+        ],
+        "title": "CtfEstimationRegisteredRequest",
+        "type": "object"
+      },
+      "FoilHoleCreateRequest": {
+        "properties": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "is_near_grid_bar": {
+            "default": false,
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
+          },
+          "quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          },
+          "x_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Location"
+          },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
+          "y_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Stage Position"
+          }
+        },
+        "required": [
+          "uuid",
+          "foilhole_id",
+          "gridsquare_id",
+          "gridsquare_uuid"
+        ],
+        "title": "FoilHoleCreateRequest",
+        "type": "object"
+      },
+      "FoilHoleResponse": {
+        "properties": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Id"
+          },
+          "is_near_grid_bar": {
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
+          },
+          "quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          },
+          "x_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Location"
+          },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
+          "y_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Stage Position"
+          }
+        },
+        "required": [
+          "uuid",
+          "gridsquare_id",
+          "foilhole_id",
+          "status",
+          "center_x",
+          "center_y",
+          "quality",
+          "rotation",
+          "size_width",
+          "size_height",
+          "x_location",
+          "y_location",
+          "x_stage_position",
+          "y_stage_position",
+          "diameter",
+          "is_near_grid_bar"
+        ],
+        "title": "FoilHoleResponse",
+        "type": "object"
+      },
+      "FoilHoleStatus": {
+        "enum": [
+          "none",
+          "micrographs detected"
+        ],
+        "title": "FoilHoleStatus",
+        "type": "string"
+      },
+      "FoilHoleUpdateRequest": {
+        "properties": {
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "diameter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diameter"
+          },
+          "foilhole_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Id"
+          },
+          "gridsquare_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Id"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "is_near_grid_bar": {
+            "default": false,
+            "title": "Is Near Grid Bar",
+            "type": "boolean"
+          },
+          "quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FoilHoleStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "x_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Location"
+          },
+          "x_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X Stage Position"
+          },
+          "y_location": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Location"
+          },
+          "y_stage_position": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y Stage Position"
+          }
+        },
+        "title": "FoilHoleUpdateRequest",
+        "type": "object"
+      },
+      "GridCreateRequest": {
+        "properties": {
+          "acquisition_uuid": {
+            "title": "Acquisition Uuid",
+            "type": "string"
+          },
+          "atlas_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Dir"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
+          "scan_start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "name",
+          "acquisition_uuid"
+        ],
+        "title": "GridCreateRequest",
+        "type": "object"
+      },
+      "GridResponse": {
+        "properties": {
+          "acquisition_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Uuid"
+          },
+          "atlas_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Dir"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
+          "scan_start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "acquisition_uuid",
+          "status",
+          "name",
+          "data_dir",
+          "atlas_dir",
+          "scan_start_time",
+          "scan_end_time"
+        ],
+        "title": "GridResponse",
+        "type": "object"
+      },
+      "GridSquare": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "default": "",
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "status": {
+            "$ref": "#/components/schemas/GridSquareStatus",
+            "default": "none"
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid"
+        ],
+        "title": "GridSquare",
+        "type": "object"
+      },
+      "GridSquareBatchCreateRequest": {
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareCreateRequest"
+            },
+            "title": "Gridsquares",
+            "type": "array"
+          }
+        },
+        "required": [
+          "gridsquares"
+        ],
+        "title": "GridSquareBatchCreateRequest",
+        "type": "object"
+      },
+      "GridSquareBatchCreateResponse": {
+        "description": "Response for bulk grid-square creation.",
+        "properties": {
+          "gridsquares": {
+            "items": {
+              "$ref": "#/components/schemas/GridSquareResponse"
+            },
+            "title": "Gridsquares",
+            "type": "array"
+          }
+        },
+        "required": [
+          "gridsquares"
+        ],
+        "title": "GridSquareBatchCreateResponse",
+        "type": "object"
+      },
+      "GridSquareCreateRequest": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "lowmag": {
+            "default": false,
+            "title": "Lowmag",
+            "type": "boolean"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridSquareStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "gridsquare_id",
+          "grid_uuid"
+        ],
+        "title": "GridSquareCreateRequest",
+        "type": "object"
+      },
+      "GridSquarePositionRequest": {
+        "properties": {
+          "center_x": {
+            "title": "Center X",
+            "type": "integer"
+          },
+          "center_y": {
+            "title": "Center Y",
+            "type": "integer"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "size_height": {
+            "title": "Size Height",
+            "type": "integer"
+          },
+          "size_width": {
+            "title": "Size Width",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "center_x",
+          "center_y",
+          "size_width",
+          "size_height"
+        ],
+        "title": "GridSquarePositionRequest",
+        "type": "object"
+      },
+      "GridSquareResponse": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "title": "Gridsquare Id",
+            "type": "string"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridSquareStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "gridsquare_id",
+          "grid_uuid",
+          "status",
+          "data_dir",
+          "atlas_node_id",
+          "state",
+          "rotation",
+          "image_path",
+          "selected",
+          "unusable",
+          "stage_position_x",
+          "stage_position_y",
+          "stage_position_z",
+          "center_x",
+          "center_y",
+          "physical_x",
+          "physical_y",
+          "size_width",
+          "size_height",
+          "acquisition_datetime",
+          "defocus",
+          "magnification",
+          "pixel_size",
+          "detector_name",
+          "applied_defocus"
+        ],
+        "title": "GridSquareResponse",
+        "type": "object"
+      },
+      "GridSquareStatus": {
+        "enum": [
+          "none",
+          "all foil holes registered",
+          "foil holes decision started",
+          "foil holes decision completed"
+        ],
+        "title": "GridSquareStatus",
+        "type": "string"
+      },
+      "GridSquareUpdateRequest": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "applied_defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Applied Defocus"
+          },
+          "atlas_node_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Node Id"
+          },
+          "center_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center X"
+          },
+          "center_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Center Y"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "grid_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grid Uuid"
+          },
+          "gridsquare_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Id"
+          },
+          "image_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Path"
+          },
+          "lowmag": {
+            "default": false,
+            "title": "Lowmag",
+            "type": "boolean"
+          },
+          "magnification": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Magnification"
+          },
+          "physical_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical X"
+          },
+          "physical_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Physical Y"
+          },
+          "pixel_size": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pixel Size"
+          },
+          "rotation": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rotation"
+          },
+          "selected": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selected"
+          },
+          "size_height": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Height"
+          },
+          "size_width": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Width"
+          },
+          "stage_position_x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position X"
+          },
+          "stage_position_y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Y"
+          },
+          "stage_position_z": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage Position Z"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridSquareStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unusable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unusable"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "GridSquareUpdateRequest",
+        "type": "object"
+      },
+      "GridStatus": {
+        "enum": [
+          "none",
+          "scan started",
+          "scan completed",
+          "grid squares decision started",
+          "grid squares decision completed"
+        ],
+        "title": "GridStatus",
+        "type": "string"
+      },
+      "GridUpdateRequest": {
+        "properties": {
+          "acquisition_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Uuid"
+          },
+          "atlas_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Atlas Dir"
+          },
+          "data_dir": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Dir"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "scan_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan End Time"
+          },
+          "scan_start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GridStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "GridUpdateRequest",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "LatentRepresentationResponse": {
+        "properties": {
+          "foilhole_uuid": {
+            "default": "",
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "default": "",
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Index"
+          },
+          "x": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "X"
+          },
+          "y": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Y"
+          }
+        },
+        "required": [
+          "x",
+          "y",
+          "index"
+        ],
+        "title": "LatentRepresentationResponse",
+        "type": "object"
+      },
+      "MicrographCreateRequest": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "energy_filter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy Filter"
+          },
+          "foilhole_id": {
+            "title": "Foilhole Id",
+            "type": "string"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
+          "image_size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size X"
+          },
+          "image_size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Y"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus",
+            "default": "none"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "foilhole_id"
+        ],
+        "title": "MicrographCreateRequest",
+        "type": "object"
+      },
+      "MicrographResponse": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "energy_filter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy Filter"
+          },
+          "foilhole_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Id"
+          },
+          "foilhole_uuid": {
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
+          "image_size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size X"
+          },
+          "image_size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Y"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
+          "micrograph_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Id"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "uuid": {
+            "title": "Uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uuid",
+          "foilhole_uuid",
+          "status"
+        ],
+        "title": "MicrographResponse",
+        "type": "object"
+      },
+      "MicrographStatus": {
+        "enum": [
+          "none",
+          "motion correction started",
+          "motion correction completed",
+          "ctf started",
+          "ctf completed",
+          "particle picking started",
+          "particle picking completed",
+          "particle selection started",
+          "particle selection completed"
+        ],
+        "title": "MicrographStatus",
+        "type": "string"
+      },
+      "MicrographUpdateRequest": {
+        "properties": {
+          "acquisition_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Acquisition Datetime"
+          },
+          "average_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Motion"
+          },
+          "binning_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning X"
+          },
+          "binning_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Binning Y"
+          },
+          "ctf_max_resolution_estimate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ctf Max Resolution Estimate"
+          },
+          "defocus": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Defocus"
+          },
+          "detector_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector Name"
+          },
+          "energy_filter": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Energy Filter"
+          },
+          "foilhole_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Id"
+          },
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "high_res_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "High Res Path"
+          },
+          "image_size_x": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size X"
+          },
+          "image_size_y": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Size Y"
+          },
+          "location_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location Id"
+          },
+          "manifest_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest File"
+          },
+          "number_of_particles_picked": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Picked"
+          },
+          "number_of_particles_rejected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Rejected"
+          },
+          "number_of_particles_selected": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Number Of Particles Selected"
+          },
+          "phase_plate": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phase Plate"
+          },
+          "pick_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pick Distribution"
+          },
+          "selection_distribution": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Selection Distribution"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MicrographStatus",
+            "default": "none"
+          },
+          "total_motion": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Motion"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          }
+        },
+        "title": "MicrographUpdateRequest",
+        "type": "object"
+      },
+      "MotionCorrectionCompletedRequest": {
+        "properties": {
+          "average_motion": {
+            "title": "Average Motion",
+            "type": "number"
+          },
+          "total_motion": {
+            "title": "Total Motion",
+            "type": "number"
+          }
+        },
+        "required": [
+          "total_motion",
+          "average_motion"
+        ],
+        "title": "MotionCorrectionCompletedRequest",
+        "type": "object"
+      },
+      "MotionCorrectionRegisteredRequest": {
+        "properties": {
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "quality": {
+            "title": "Quality",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "quality"
+        ],
+        "title": "MotionCorrectionRegisteredRequest",
+        "type": "object"
+      },
+      "OverallQualityPrediction": {
+        "properties": {
+          "foilhole_uuid": {
+            "title": "Foilhole Uuid",
+            "type": "string"
+          },
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "gridsquare_uuid": {
+            "title": "Gridsquare Uuid",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "suggested_acquisition_index": {
+            "title": "Suggested Acquisition Index",
+            "type": "integer"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "suggested_acquisition_index",
+          "foilhole_uuid",
+          "grid_uuid",
+          "gridsquare_uuid"
+        ],
+        "title": "OverallQualityPrediction",
+        "type": "object"
+      },
+      "ProcessingFeedbackPublishResponse": {
+        "description": "Confirmation that a processing-feedback event was published to RabbitMQ.",
+        "properties": {
+          "published": {
+            "title": "Published",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "published"
+        ],
+        "title": "ProcessingFeedbackPublishResponse",
+        "type": "object"
+      },
+      "QualityMetricsResponse": {
+        "properties": {
+          "average_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Average Quality"
+          },
+          "max_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Quality"
+          },
+          "min_quality": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Quality"
+          },
+          "models_count": {
+            "title": "Models Count",
+            "type": "integer"
+          },
+          "total_predictions": {
+            "title": "Total Predictions",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total_predictions",
+          "average_quality",
+          "min_quality",
+          "max_quality",
+          "models_count"
+        ],
+        "title": "QualityMetricsResponse",
+        "type": "object"
+      },
+      "QualityPrediction": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "prediction_model_name"
+        ],
+        "title": "QualityPrediction",
+        "type": "object"
+      },
+      "QualityPredictionCreateRequest": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "value",
+          "prediction_model_name"
+        ],
+        "title": "QualityPredictionCreateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelCreateRequest": {
+        "properties": {
+          "can_infer": {
+            "default": true,
+            "title": "Can Infer",
+            "type": "boolean"
+          },
+          "can_train": {
+            "default": false,
+            "title": "Can Train",
+            "type": "boolean"
+          },
+          "can_update": {
+            "default": false,
+            "title": "Can Update",
+            "type": "boolean"
+          },
+          "description": {
+            "default": "",
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "QualityPredictionModelCreateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelParameterResponse": {
+        "properties": {
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "group": {
+            "title": "Group",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "grid_uuid",
+          "timestamp",
+          "prediction_model_name",
+          "key",
+          "value",
+          "group"
+        ],
+        "title": "QualityPredictionModelParameterResponse",
+        "type": "object"
+      },
+      "QualityPredictionModelResponse": {
+        "properties": {
+          "can_infer": {
+            "title": "Can Infer",
+            "type": "boolean"
+          },
+          "can_train": {
+            "title": "Can Train",
+            "type": "boolean"
+          },
+          "can_update": {
+            "title": "Can Update",
+            "type": "boolean"
+          },
+          "description": {
+            "title": "Description",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "can_train",
+          "can_infer",
+          "can_update"
+        ],
+        "title": "QualityPredictionModelResponse",
+        "type": "object"
+      },
+      "QualityPredictionModelUpdateRequest": {
+        "properties": {
+          "can_infer": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Infer"
+          },
+          "can_train": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Train"
+          },
+          "can_update": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Can Update"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "title": "QualityPredictionModelUpdateRequest",
+        "type": "object"
+      },
+      "QualityPredictionModelWeight": {
+        "properties": {
+          "grid_uuid": {
+            "title": "Grid Uuid",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "metric_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric Name"
+          },
+          "micrograph_quality": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Quality"
+          },
+          "micrograph_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Micrograph Uuid"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "prediction_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prediction Value"
+          },
+          "quality_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality Score"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "weight": {
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "grid_uuid",
+          "prediction_model_name",
+          "weight"
+        ],
+        "title": "QualityPredictionModelWeight",
+        "type": "object"
+      },
+      "QualityPredictionResponse": {
+        "properties": {
+          "foilhole_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Foilhole Uuid"
+          },
+          "gridsquare_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gridsquare Uuid"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "prediction_model_name": {
+            "title": "Prediction Model Name",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "prediction_model_name",
+          "value",
+          "timestamp"
+        ],
+        "title": "QualityPredictionResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "API for accessing and managing electron microscopy data",
+    "title": "SmartEM Decisions Backend API",
+    "version": "0.1.1rc48.dev3+gcd5206327"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/acquisitions": {
+      "get": {
+        "description": "Get all acquisitions",
+        "operationId": "get_acquisitions_acquisitions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionResponse"
+                  },
+                  "title": "Response Get Acquisitions Acquisitions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Acquisitions"
+      },
+      "post": {
+        "description": "Create a new acquisition",
+        "operationId": "create_acquisition_acquisitions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Acquisition"
+      }
+    },
+    "/acquisitions/grid-counts": {
+      "get": {
+        "description": "Per-acquisition grid totals for summary views.\n\nA single grouped query in place of one /acquisitions/{uuid}/grids call per\nacquisition. Every acquisition is returned, including those with no grids\n(grids_total == 0), via an outer join. Declared before the\n/acquisitions/{acquisition_uuid} route so the static segment is matched\nfirst rather than being parsed as a uuid.",
+        "operationId": "get_acquisition_grid_counts_acquisitions_grid_counts_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AcquisitionGridCountResponse"
+                  },
+                  "title": "Response Get Acquisition Grid Counts Acquisitions Grid Counts Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Acquisition Grid Counts"
+      }
+    },
+    "/acquisitions/{acquisition_uuid}": {
+      "delete": {
+        "description": "Delete an acquisition",
+        "operationId": "delete_acquisition_acquisitions__acquisition_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Acquisition"
+      },
+      "get": {
+        "description": "Get a single acquisition by ID",
+        "operationId": "get_acquisition_acquisitions__acquisition_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Acquisition"
+      },
+      "put": {
+        "description": "Update an acquisition",
+        "operationId": "update_acquisition_acquisitions__acquisition_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AcquisitionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcquisitionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Acquisition"
+      }
+    },
+    "/acquisitions/{acquisition_uuid}/grids": {
+      "get": {
+        "description": "Get all grids for a specific acquisition",
+        "operationId": "get_acquisition_grids_acquisitions__acquisition_uuid__grids_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "title": "Response Get Acquisition Grids Acquisitions  Acquisition Uuid  Grids Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Acquisition Grids"
+      },
+      "post": {
+        "description": "Create a new grid for a specific acquisition",
+        "operationId": "create_acquisition_grid_acquisitions__acquisition_uuid__grids_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "acquisition_uuid",
+            "required": true,
+            "schema": {
+              "title": "Acquisition Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Acquisition Grid"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/heartbeat": {
+      "post": {
+        "description": "Agent heartbeat endpoint to update connection health status.\n\nArgs:\n    agent_id: The agent identifier\n    session_id: The session identifier\n    db: Database session\n\nReturns:\n    Heartbeat response with status and timestamp",
+        "operationId": "agent_heartbeat_agent__agent_id__session__session_id__heartbeat_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Agent Heartbeat"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/stream": {
+      "get": {
+        "description": "SSE endpoint for streaming instructions to agents for a specific session.\n\nUses PostgreSQL LISTEN/NOTIFY (channel `agent_instructions`, payload = session_id)\ninstead of polling: a dedicated asyncpg connection holds a LISTEN, the main loop\nawaits the next notification or a heartbeat timeout, and only queries the\ndatabase when a notification arrives or on initial connect.",
+        "operationId": "stream_instructions_agent__agent_id__session__session_id__instructions_stream_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stream Instructions"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/instructions/{instruction_id}/ack": {
+      "post": {
+        "description": "HTTP endpoint for instruction acknowledgements with database persistence",
+        "operationId": "acknowledge_instruction_agent__agent_id__session__session_id__instructions__instruction_id__ack_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "instruction_id",
+            "required": true,
+            "schema": {
+              "title": "Instruction Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionAcknowledgement"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructionAcknowledgementResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Acknowledge Instruction"
+      }
+    },
+    "/agent/{agent_id}/session/{session_id}/logs": {
+      "post": {
+        "operationId": "ingest_agent_logs_agent__agent_id__session__session_id__logs_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agent_id",
+            "required": true,
+            "schema": {
+              "title": "Agent Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentLogBatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentLogBatchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Agent Logs"
+      }
+    },
+    "/atlas-tiles": {
+      "get": {
+        "description": "Get all atlas tiles",
+        "operationId": "get_atlas_tiles_atlas_tiles_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "title": "Response Get Atlas Tiles Atlas Tiles Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Atlas Tiles"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}": {
+      "delete": {
+        "description": "Delete an atlas tile by publishing to RabbitMQ",
+        "operationId": "delete_atlas_tile_atlas_tiles__tile_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Atlas Tile"
+      },
+      "get": {
+        "description": "Get a single atlas tile by ID",
+        "operationId": "get_atlas_tile_atlas_tiles__tile_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas Tile"
+      },
+      "put": {
+        "description": "Update an atlas tile",
+        "operationId": "update_atlas_tile_atlas_tiles__tile_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Atlas Tile"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares": {
+      "post": {
+        "description": "Connect mutliple grid squares to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquares_atlas_tiles__tile_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/GridSquarePositionRequest"
+                },
+                "title": "Gridsquare Positions",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                  },
+                  "title": "Response Link Atlas Tile To Gridsquares Atlas Tiles  Tile Uuid  Gridsquares Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Link Atlas Tile To Gridsquares"
+      }
+    },
+    "/atlas-tiles/{tile_uuid}/gridsquares/{gridsquare_uuid}": {
+      "post": {
+        "description": "Connect a grid square to a tile with its position information",
+        "operationId": "link_atlas_tile_to_gridsquare_atlas_tiles__tile_uuid__gridsquares__gridsquare_uuid__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tile_uuid",
+            "required": true,
+            "schema": {
+              "title": "Tile Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquarePositionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileGridSquarePositionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Link Atlas Tile To Gridsquare"
+      }
+    },
+    "/atlases": {
+      "get": {
+        "description": "Get all atlases",
+        "operationId": "get_atlases_atlases_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasResponse"
+                  },
+                  "title": "Response Get Atlases Atlases Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Atlases"
+      }
+    },
+    "/atlases/{atlas_uuid}": {
+      "delete": {
+        "description": "Delete an atlas by publishing to RabbitMQ",
+        "operationId": "delete_atlas_atlases__atlas_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Atlas"
+      },
+      "get": {
+        "description": "Get a single atlas by ID",
+        "operationId": "get_atlas_atlases__atlas_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas"
+      },
+      "put": {
+        "description": "Update an atlas",
+        "operationId": "update_atlas_atlases__atlas_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Atlas"
+      }
+    },
+    "/atlases/{atlas_uuid}/tiles": {
+      "get": {
+        "description": "Get all tiles for a specific atlas",
+        "operationId": "get_atlas_tiles_by_atlas_atlases__atlas_uuid__tiles_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AtlasTileResponse"
+                  },
+                  "title": "Response Get Atlas Tiles By Atlas Atlases  Atlas Uuid  Tiles Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Atlas Tiles By Atlas"
+      },
+      "post": {
+        "description": "Create a new tile for a specific atlas",
+        "operationId": "create_atlas_tile_for_atlas_atlases__atlas_uuid__tiles_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "atlas_uuid",
+            "required": true,
+            "schema": {
+              "title": "Atlas Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasTileCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasTileResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Atlas Tile For Atlas"
+      }
+    },
+    "/debug/agent-connections": {
+      "get": {
+        "description": "Debug endpoint to view active agent connections",
+        "operationId": "get_active_connections_debug_agent_connections_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Active Connections"
+      }
+    },
+    "/debug/connection-stats": {
+      "get": {
+        "description": "Get real-time connection and session statistics",
+        "operationId": "get_connection_stats_debug_connection_stats_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Connection Stats"
+      }
+    },
+    "/debug/session/{session_id}/create-instruction": {
+      "post": {
+        "description": "Debug endpoint to create test instructions",
+        "operationId": "create_test_instruction_debug_session__session_id__create_instruction_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Instruction Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Test Instruction"
+      }
+    },
+    "/debug/session/{session_id}/instructions": {
+      "get": {
+        "description": "Debug endpoint to view instructions for a session",
+        "operationId": "get_session_instructions_debug_session__session_id__instructions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Session Instructions"
+      }
+    },
+    "/debug/sessions": {
+      "get": {
+        "description": "Debug endpoint to view all active sessions",
+        "operationId": "get_active_sessions_debug_sessions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Active Sessions"
+      }
+    },
+    "/debug/sessions/create": {
+      "post": {
+        "description": "Debug endpoint to create test sessions",
+        "operationId": "create_test_session_debug_sessions_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Session Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Test Session"
+      }
+    },
+    "/debug/sessions/create-managed": {
+      "post": {
+        "description": "Create a session using the connection manager",
+        "operationId": "create_managed_session_debug_sessions_create_managed_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Session Data",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Managed Session"
+      }
+    },
+    "/debug/sessions/{session_id}/close": {
+      "delete": {
+        "description": "Close a session using the connection manager",
+        "operationId": "close_managed_session_debug_sessions__session_id__close_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Close Managed Session"
+      }
+    },
+    "/foilholes": {
+      "get": {
+        "description": "Get all foil holes",
+        "operationId": "get_foilholes_foilholes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Get Foilholes Foilholes Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Foilholes"
+      }
+    },
+    "/foilholes/{foilhole_uuid}": {
+      "delete": {
+        "description": "Delete a foil hole by publishing to RabbitMQ",
+        "operationId": "delete_foilhole_foilholes__foilhole_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Foilhole"
+      },
+      "get": {
+        "description": "Get a single foil hole by ID",
+        "operationId": "get_foilhole_foilholes__foilhole_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole"
+      },
+      "put": {
+        "description": "Update a foil hole",
+        "operationId": "update_foilhole_foilholes__foilhole_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FoilHoleUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FoilHoleResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Foilhole"
+      }
+    },
+    "/foilholes/{foilhole_uuid}/micrographs": {
+      "get": {
+        "description": "Get all micrographs for a specific foil hole",
+        "operationId": "get_foilhole_micrographs_foilholes__foilhole_uuid__micrographs_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "title": "Response Get Foilhole Micrographs Foilholes  Foilhole Uuid  Micrographs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Micrographs"
+      },
+      "post": {
+        "description": "Create a new micrograph for a specific foil hole",
+        "operationId": "create_foilhole_micrograph_foilholes__foilhole_uuid__micrographs_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "foilhole_uuid",
+            "required": true,
+            "schema": {
+              "title": "Foilhole Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Foilhole Micrograph"
+      }
+    },
+    "/frontend/events/stream": {
+      "get": {
+        "operationId": "frontend_event_stream_frontend_events_stream_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "acquisition_uuid",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Acquisition Uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "event_types",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Types"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Frontend Event Stream"
+      }
+    },
+    "/grid/{grid_uuid}/model_weights": {
+      "get": {
+        "description": "Get time series of model weights for grid",
+        "operationId": "get_model_weights_for_grid_grid__grid_uuid__model_weights_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPredictionModelWeight"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Model Weights For Grid Grid  Grid Uuid  Model Weights Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Model Weights For Grid"
+      }
+    },
+    "/grid/{grid_uuid}/prediction_model/{prediction_model_name}/latent_rep/{latent_rep_model_name}/suggested_squares": {
+      "get": {
+        "operationId": "get_suggested_square_collections_grid__grid_uuid__prediction_model__prediction_model_name__latent_rep__latent_rep_model_name__suggested_squares_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "latent_rep_model_name",
+            "required": true,
+            "schema": {
+              "title": "Latent Rep Model Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquare"
+                  },
+                  "title": "Response Get Suggested Square Collections Grid  Grid Uuid  Prediction Model  Prediction Model Name  Latent Rep  Latent Rep Model Name  Suggested Squares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Suggested Square Collections"
+      }
+    },
+    "/grids": {
+      "get": {
+        "description": "Get all grids",
+        "operationId": "get_grids_grids_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridResponse"
+                  },
+                  "title": "Response Get Grids Grids Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Grids"
+      }
+    },
+    "/grids/{grid_uuid}": {
+      "delete": {
+        "description": "Delete a grid by publishing to RabbitMQ",
+        "operationId": "delete_grid_grids__grid_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Grid"
+      },
+      "get": {
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_grids__grid_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid"
+      },
+      "put": {
+        "description": "Update a grid",
+        "operationId": "update_grid_grids__grid_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Grid"
+      }
+    },
+    "/grids/{grid_uuid}/atlas": {
+      "get": {
+        "description": "Get the atlas for a specific grid",
+        "operationId": "get_grid_atlas_grids__grid_uuid__atlas_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Atlas"
+      },
+      "post": {
+        "description": "Create a new atlas for a grid",
+        "operationId": "create_grid_atlas_grids__grid_uuid__atlas_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtlasCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtlasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Atlas"
+      }
+    },
+    "/grids/{grid_uuid}/atlas_image": {
+      "get": {
+        "description": "Get a single grid by ID",
+        "operationId": "get_grid_atlas_image_grids__grid_uuid__atlas_image_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "x",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X"
+            }
+          },
+          {
+            "in": "query",
+            "name": "y",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Y"
+            }
+          },
+          {
+            "in": "query",
+            "name": "w",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "W"
+            }
+          },
+          {
+            "in": "query",
+            "name": "h",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "H"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Atlas Image"
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares": {
+      "get": {
+        "description": "Get all grid squares for a specific grid",
+        "operationId": "get_grid_gridsquares_grids__grid_uuid__gridsquares_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "title": "Response Get Grid Gridsquares Grids  Grid Uuid  Gridsquares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Grid Gridsquares"
+      },
+      "post": {
+        "description": "Create a new grid square for a specific grid",
+        "operationId": "create_grid_gridsquare_grids__grid_uuid__gridsquares_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Gridsquare"
+      }
+    },
+    "/grids/{grid_uuid}/gridsquares/batch": {
+      "post": {
+        "description": "Create many grid squares for a grid in a single transaction and a single\nbatched RabbitMQ publish. Solves the overload scenario from issue #249.",
+        "operationId": "create_grid_gridsquares_batch_grids__grid_uuid__gridsquares_batch_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareBatchCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareBatchCreateResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Grid Gridsquares Batch"
+      }
+    },
+    "/grids/{grid_uuid}/registered": {
+      "post": {
+        "description": "All squares on a grid have been registered at low mag",
+        "operationId": "grid_registered_grids__grid_uuid__registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Grid Registered Grids  Grid Uuid  Registered Post",
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Grid Registered"
+      }
+    },
+    "/gridsquare/{gridsquare_uuid}/overall_prediction": {
+      "get": {
+        "operationId": "get_overall_prediction_for_gridsquare_gridsquare__gridsquare_uuid__overall_prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/OverallQualityPrediction"
+                  },
+                  "title": "Response Get Overall Prediction For Gridsquare Gridsquare  Gridsquare Uuid  Overall Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Overall Prediction For Gridsquare"
+      }
+    },
+    "/gridsquares": {
+      "get": {
+        "description": "Get all grid squares",
+        "operationId": "get_gridsquares_gridsquares_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GridSquareResponse"
+                  },
+                  "title": "Response Get Gridsquares Gridsquares Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Gridsquares"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}": {
+      "delete": {
+        "description": "Delete a grid square by publishing to RabbitMQ",
+        "operationId": "delete_gridsquare_gridsquares__gridsquare_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Gridsquare"
+      },
+      "get": {
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_gridsquares__gridsquare_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare"
+      },
+      "put": {
+        "description": "Update a grid square",
+        "operationId": "update_gridsquare_gridsquares__gridsquare_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GridSquareUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GridSquareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Gridsquare"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      },
+                      "type": "array"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/foilholes": {
+      "get": {
+        "description": "Get all foil holes for a specific grid square",
+        "operationId": "get_gridsquare_foilholes_gridsquares__gridsquare_uuid__foilholes_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "on_square_only",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "On Square Only",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Get Gridsquare Foilholes Gridsquares  Gridsquare Uuid  Foilholes Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Foilholes"
+      },
+      "post": {
+        "description": "Create a new foil hole for a specific grid square",
+        "operationId": "create_gridsquare_foilhole_gridsquares__gridsquare_uuid__foilholes_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/FoilHoleCreateRequest"
+                },
+                "title": "Foilholes",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FoilHoleResponse"
+                  },
+                  "title": "Response Create Gridsquare Foilhole Gridsquares  Gridsquare Uuid  Foilholes Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Gridsquare Foilhole"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/gridsquare_image": {
+      "get": {
+        "description": "Get a single grid square by ID",
+        "operationId": "get_gridsquare_image_gridsquares__gridsquare_uuid__gridsquare_image_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "image/png": {}
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Image"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_gridsquare_quality_prediction_time_series_gridsquares__gridsquare_uuid__quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/QualityPrediction"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Gridsquare Quality Prediction Time Series Gridsquares  Gridsquare Uuid  Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Gridsquare Quality Prediction Time Series"
+      }
+    },
+    "/gridsquares/{gridsquare_uuid}/registered": {
+      "post": {
+        "description": "All holes on a grid square have been registered at square mag",
+        "operationId": "gridsquare_registered_gridsquares__gridsquare_uuid__registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "count",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Count"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Response Gridsquare Registered Gridsquares  Gridsquare Uuid  Registered Post",
+                  "type": "boolean"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Gridsquare Registered"
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Health check endpoint with actual connectivity checks",
+        "operationId": "get_health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Health"
+      }
+    },
+    "/micrographs": {
+      "get": {
+        "description": "Get all micrographs",
+        "operationId": "get_micrographs_micrographs_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MicrographResponse"
+                  },
+                  "title": "Response Get Micrographs Micrographs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Micrographs"
+      }
+    },
+    "/micrographs/{micrograph_uuid}": {
+      "delete": {
+        "description": "Delete a micrograph by publishing to RabbitMQ",
+        "operationId": "delete_micrograph_micrographs__micrograph_uuid__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Micrograph"
+      },
+      "get": {
+        "description": "Get a single micrograph by ID",
+        "operationId": "get_micrograph_micrographs__micrograph_uuid__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Micrograph"
+      },
+      "put": {
+        "description": "Update a micrograph",
+        "operationId": "update_micrograph_micrographs__micrograph_uuid__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MicrographUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MicrographResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Micrograph"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/completed": {
+      "post": {
+        "description": "Publish a CTF-estimation-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_completed_micrographs__micrograph_uuid__ctf_estimation_completed_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationCompletedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Ctf Estimation Completed"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/ctf_estimation/registered": {
+      "post": {
+        "description": "Publish a CTF-estimation-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_ctf_estimation_registered_micrographs__micrograph_uuid__ctf_estimation_registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CtfEstimationRegisteredRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Ctf Estimation Registered"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/completed": {
+      "post": {
+        "description": "Publish a motion-correction-completed event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_completed_micrographs__micrograph_uuid__motion_correction_completed_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionCompletedRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Motion Correction Completed"
+      }
+    },
+    "/micrographs/{micrograph_uuid}/motion_correction/registered": {
+      "post": {
+        "description": "Publish a motion-correction-registered event for a micrograph to RabbitMQ.",
+        "operationId": "publish_micrograph_motion_correction_registered_micrographs__micrograph_uuid__motion_correction_registered_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "micrograph_uuid",
+            "required": true,
+            "schema": {
+              "title": "Micrograph Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MotionCorrectionRegisteredRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessingFeedbackPublishResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Micrograph Motion Correction Registered"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation": {
+      "get": {
+        "operationId": "get_latent_rep_prediction_model__prediction_model_name__grid__grid_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Latent Rep Prediction Model  Prediction Model Name  Grid  Grid Uuid  Latent Representation Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Latent Rep"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction": {
+      "get": {
+        "operationId": "get_prediction_for_grid_prediction_model__prediction_model_name__grid__grid_uuid__prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "grid_uuid",
+            "required": true,
+            "schema": {
+              "title": "Grid Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Grid Prediction Model  Prediction Model Name  Grid  Grid Uuid  Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction For Grid"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/latent_representation": {
+      "get": {
+        "operationId": "get_square_latent_rep_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__latent_representation_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LatentRepresentationResponse"
+                  },
+                  "title": "Response Get Square Latent Rep Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Latent Representation Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Square Latent Rep"
+      }
+    },
+    "/prediction_model/{prediction_model_name}/gridsquare/{gridsquare_uuid}/prediction": {
+      "get": {
+        "operationId": "get_prediction_for_gridsquare_prediction_model__prediction_model_name__gridsquare__gridsquare_uuid__prediction_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "prediction_model_name",
+            "required": true,
+            "schema": {
+              "title": "Prediction Model Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionResponse"
+                  },
+                  "title": "Response Get Prediction For Gridsquare Prediction Model  Prediction Model Name  Gridsquare  Gridsquare Uuid  Prediction Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction For Gridsquare"
+      }
+    },
+    "/prediction_models": {
+      "get": {
+        "operationId": "get_prediction_models_prediction_models_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                  },
+                  "title": "Response Get Prediction Models Prediction Models Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Prediction Models"
+      },
+      "post": {
+        "operationId": "create_prediction_model_prediction_models_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Prediction Model"
+      }
+    },
+    "/prediction_models/{name}": {
+      "delete": {
+        "operationId": "delete_prediction_model_prediction_models__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Prediction Model"
+      },
+      "get": {
+        "operationId": "get_prediction_model_prediction_models__name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Prediction Model"
+      },
+      "put": {
+        "operationId": "update_prediction_model_prediction_models__name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionModelUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionModelResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Prediction Model"
+      }
+    },
+    "/quality_metric/{metric_name}/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions": {
+      "get": {
+        "description": "Get time ordered predictions for all models that provide them for this square",
+        "operationId": "get_foilhole_quality_prediction_time_series_for_gridsquare_for_metric_quality_metric__metric_name__gridsquares__gridsquare_uuid__foilhole_quality_predictions_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "metric_name",
+            "required": true,
+            "schema": {
+              "title": "Metric Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "gridsquare_uuid",
+            "required": true,
+            "schema": {
+              "title": "Gridsquare Uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "additionalProperties": {
+                      "items": {
+                        "$ref": "#/components/schemas/QualityPrediction"
+                      },
+                      "type": "array"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Get Foilhole Quality Prediction Time Series For Gridsquare For Metric Quality Metric  Metric Name  Gridsquares  Gridsquare Uuid  Foilhole Quality Predictions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Foilhole Quality Prediction Time Series For Gridsquare For Metric"
+      }
+    },
+    "/quality_metrics": {
+      "get": {
+        "operationId": "get_quality_metrics_quality_metrics_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityMetricsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Quality Metrics"
+      }
+    },
+    "/quality_predictions": {
+      "post": {
+        "operationId": "create_quality_prediction_quality_predictions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityPredictionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityPredictionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Quality Prediction"
+      }
+    },
+    "/status": {
+      "get": {
+        "description": "Get API status and configuration information",
+        "operationId": "get_status_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Status"
+      }
+    },
+    "/version": {
+      "get": {
+        "description": "Machine-readable API version for client compatibility checks.\n\nThe frontend's boot-time check (ADR 0020) reads `version` here and compares\nit semantically against the backend API version its client was generated\nagainst. Kept deliberately small and stable; `/status` carries the richer\ndiagnostic payload.",
+        "operationId": "get_version_version_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Version"
+      }
+    }
+  }
+}

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -337,6 +337,18 @@ async def get_status():
     }
 
 
+@app.get("/version")
+async def get_version():
+    """Machine-readable API version for client compatibility checks.
+
+    The frontend's boot-time check (ADR 0020) reads `version` here and compares
+    it semantically against the backend API version its client was generated
+    against. Kept deliberately small and stable; `/status` carries the richer
+    diagnostic payload.
+    """
+    return {"service": "smartem-decisions", "version": __version__}
+
+
 @app.get("/health")
 async def get_health():
     """Health check endpoint with actual connectivity checks"""

--- a/tests/smartem_backend/test_misc_endpoints.py
+++ b/tests/smartem_backend/test_misc_endpoints.py
@@ -20,6 +20,15 @@ class TestGetStatus:
         assert body["endpoints"]["health"] == "/health"
 
 
+class TestGetVersion:
+    def test_returns_service_and_version(self, client):
+        resp = client.get("/version")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["service"] == "smartem-decisions"
+        assert isinstance(body["version"], str) and body["version"]
+
+
 class TestGetHealth:
     @pytest.fixture
     def patch_health_checks(self, monkeypatch):

--- a/tools/publish_openapi.py
+++ b/tools/publish_openapi.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Regenerate the canonical OpenAPI spec and report whether the API content changed.
+
+This repository is the canonical publisher of the SmartEM OpenAPI specification
+(ADR 0020). The committed spec lives at ``docs/api/openapi.json`` and downstream
+repositories (smartem-frontend, smartem-devtools) consume it.
+
+``info.version`` is ``setuptools_scm``-derived and changes on every commit, so a
+naive diff would report a change every time. We therefore compare the spec with
+the volatile ``info.version`` and ``servers`` normalised out, and rewrite the file
+only when the actual API surface differs. When it does, the freshly generated spec
+(carrying the current version) is written, so the committed version marks the
+commit at which the contract last changed.
+
+Prints ``changed=true`` or ``changed=false`` to stdout (consumed by CI).
+"""
+
+import json
+import os
+from pathlib import Path
+
+os.environ.setdefault("SKIP_DB_INIT", "true")
+
+from smartem_backend.api_server import app  # noqa: E402
+
+DEST = Path("docs/api/openapi.json")
+
+
+def _content_only(spec: dict) -> str:
+    """Serialise the spec with the volatile fields removed, for change detection."""
+    clone = json.loads(json.dumps(spec))
+    clone.get("info", {}).pop("version", None)
+    clone.pop("servers", None)
+    return json.dumps(clone, sort_keys=True)
+
+
+def main() -> None:
+    new_spec = app.openapi()
+    changed = True
+    if DEST.exists():
+        existing = json.loads(DEST.read_text())
+        changed = _content_only(existing) != _content_only(new_spec)
+
+    if changed:
+        DEST.parent.mkdir(parents=True, exist_ok=True)
+        DEST.write_text(json.dumps(new_spec, indent=2, sort_keys=True) + "\n")
+
+    print(f"changed={'true' if changed else 'false'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes smartem-decisions the **canonical OpenAPI spec publisher** (ADR 0020 — DiamondLightSource/smartem-devtools#222) and adds the `/version` contract the frontend's compatibility check reads.

- **`docs/api/openapi.json`** — the canonical spec, now committed in-repo (the single source; frontend and devtools are downstream caches of it).
- **`publish-openapi-spec.yml`** — on pushes to `main` touching the backend, regenerates the spec; when the API surface actually changes (per-commit version churn ignored via `tools/publish_openapi.py`), commits the refresh and fires a `repository_dispatch` to smartem-devtools to refresh its caches + rebuild Pages.
- **`GET /version`** — small, stable, machine-readable (`{service, version}`); `/status` is unchanged.

## Action required after merge

Add a **`DEVTOOLS_DISPATCH_TOKEN`** secret (fine-grained PAT with `Contents: write` on smartem-devtools, or a GitHub App). The publish workflow degrades gracefully without it — it still commits the spec and logs a warning; the devtools sync can be run manually meanwhile.

## Companion PRs (merge together)

- DiamondLightSource/smartem-devtools#222 — receiver + ADR 0020.
- DiamondLightSource/smartem-frontend#XXX — observe-only version check.

## Test plan

- [x] `uv run pytest tests/smartem_backend/test_misc_endpoints.py` — `/version` covered, suite green
- [x] `ruff check` / `format --check` clean
- [x] Canonical spec generates (62 paths incl. `/version` and `/acquisitions/grid-counts`); change-detection ignores version churn

Closes #253.