### PR TITLE
fix(ci): make devtools dispatch best-effort in publish-openapi-spec

### DIFF
--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -60,5 +60,10 @@ jobs:
             echo "::warning::DEVTOOLS_DISPATCH_TOKEN not set - spec committed but smartem-devtools not notified."
             exit 0
           fi
-          gh api repos/DiamondLightSource/smartem-devtools/dispatches \
-            -f event_type=openapi-spec-updated
+          # Best-effort nudge: the spec commit above is the critical output, and
+          # smartem-devtools also syncs on a schedule and on manual dispatch, so a
+          # failed notification (e.g. a token pending org approval) must not fail
+          # this workflow.
+          if ! gh api repos/DiamondLightSource/smartem-devtools/dispatches -f event_type=openapi-spec-updated; then
+            echo "::warning::Could not notify smartem-devtools (token pending approval or transient error). Spec is committed; devtools will pick it up via its scheduled or manual sync."
+          fi


### PR DESCRIPTION
## Summary

Follow-up to #292. The first post-merge `Publish OpenAPI spec` run committed the canonical spec correctly but then **failed** on the `Notify smartem-devtools` step: the `DEVTOOLS_DISPATCH_TOKEN` is present but pending org approval, so `gh api .../dispatches` returns 403.

The notification is a best-effort nudge — the spec commit is the critical output, and smartem-devtools also syncs on a daily schedule and via manual `workflow_dispatch`. A failed dispatch should therefore **warn**, not fail the workflow. The previous guard only handled an *absent* token, not a present-but-unauthorised one.

No functional change once the token is approved; this just stops a transient/pending-token state from reding `main`.