### PR TITLE
fix: de-duplicate shadowed route registrations (#298)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4472,50 +4472,6 @@
         "title": "QualityPredictionModelCreateRequest",
         "type": "object"
       },
-      "QualityPredictionModelParameterResponse": {
-        "properties": {
-          "grid_uuid": {
-            "title": "Grid Uuid",
-            "type": "string"
-          },
-          "group": {
-            "title": "Group",
-            "type": "string"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "key": {
-            "title": "Key",
-            "type": "string"
-          },
-          "prediction_model_name": {
-            "title": "Prediction Model Name",
-            "type": "string"
-          },
-          "timestamp": {
-            "format": "date-time",
-            "title": "Timestamp",
-            "type": "string"
-          },
-          "value": {
-            "title": "Value",
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "grid_uuid",
-          "timestamp",
-          "prediction_model_name",
-          "key",
-          "value",
-          "group"
-        ],
-        "title": "QualityPredictionModelParameterResponse",
-        "type": "object"
-      },
       "QualityPredictionModelResponse": {
         "properties": {
           "can_infer": {
@@ -4746,13 +4702,6 @@
       },
       "ValidationError": {
         "properties": {
-          "ctx": {
-            "title": "Context",
-            "type": "object"
-          },
-          "input": {
-            "title": "Input"
-          },
           "loc": {
             "items": {
               "anyOf": [
@@ -4789,7 +4738,7 @@
   "info": {
     "description": "API for accessing and managing electron microscopy data",
     "title": "SmartEM Decisions Backend API",
-    "version": "0.1.1rc48.dev5+g8fa353eea"
+    "version": "0.1.1rc48.dev3+gcd5206327"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -107,7 +107,6 @@ from smartem_backend.model.http_response import (
     MicrographResponse,
     ProcessingFeedbackPublishResponse,
     QualityMetricsResponse,
-    QualityPredictionModelParameterResponse,
     QualityPredictionModelResponse,
     QualityPredictionResponse,
 )
@@ -1559,33 +1558,6 @@ async def delete_prediction_model(name: str, db: AsyncSession = DB_DEPENDENCY):
 # ============ Quality Prediction Endpoints ============
 
 
-@app.get("/gridsquares/{gridsquare_uuid}/quality_predictions", response_model=list[QualityPredictionResponse])
-async def get_gridsquare_quality_predictions(gridsquare_uuid: str, db: AsyncSession = DB_DEPENDENCY):
-    gridsquare = (await db.execute(select(GridSquare).where(GridSquare.uuid == gridsquare_uuid))).scalars().first()
-    if not gridsquare:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"GridSquare {gridsquare_uuid} not found")
-    predictions = (
-        (await db.execute(select(QualityPrediction).where(QualityPrediction.gridsquare_uuid == gridsquare_uuid)))
-        .scalars()
-        .all()
-    )
-    return [QualityPredictionResponse.model_validate(pred) for pred in predictions]
-
-
-@app.get("/gridsquares/{gridsquare_uuid}/foilhole_quality_predictions", response_model=list[QualityPredictionResponse])
-async def get_gridsquare_foilhole_quality_predictions(gridsquare_uuid: str, db: AsyncSession = DB_DEPENDENCY):
-    gridsquare = (await db.execute(select(GridSquare).where(GridSquare.uuid == gridsquare_uuid))).scalars().first()
-    if not gridsquare:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"GridSquare {gridsquare_uuid} not found")
-    foilhole_uuids = [fh.uuid for fh in gridsquare.foilholes]
-    predictions = (
-        (await db.execute(select(QualityPrediction).where(QualityPrediction.foilhole_uuid.in_(foilhole_uuids))))
-        .scalars()
-        .all()
-    )
-    return [QualityPredictionResponse.model_validate(pred) for pred in predictions]
-
-
 @app.post("/quality_predictions", response_model=QualityPredictionResponse, status_code=status.HTTP_201_CREATED)
 async def create_quality_prediction(request: QualityPredictionCreateRequest, db: AsyncSession = DB_DEPENDENCY):
     if request.foilhole_uuid:
@@ -1639,77 +1611,6 @@ async def get_quality_metrics(db: AsyncSession = DB_DEPENDENCY):
         max_quality=float(max_quality) if max_quality is not None else None,
         models_count=models_count,
     )
-
-
-@app.get(
-    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/prediction",
-    response_model=list[QualityPredictionResponse],
-)
-async def get_grid_predictions(prediction_model_name: str, grid_uuid: str, db: AsyncSession = DB_DEPENDENCY):
-    grid = (await db.execute(select(Grid).where(Grid.uuid == grid_uuid))).scalars().first()
-    if not grid:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Grid {grid_uuid} not found")
-    model = (
-        (await db.execute(select(QualityPredictionModel).where(QualityPredictionModel.name == prediction_model_name)))
-        .scalars()
-        .first()
-    )
-    if not model:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Prediction model {prediction_model_name} not found",
-        )
-    gridsquare_uuids = [gs.uuid for gs in grid.gridsquares]
-    predictions = (
-        (
-            await db.execute(
-                select(QualityPrediction).where(
-                    and_(
-                        QualityPrediction.prediction_model_name == prediction_model_name,
-                        QualityPrediction.gridsquare_uuid.in_(gridsquare_uuids),
-                    )
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    return [QualityPredictionResponse.model_validate(pred) for pred in predictions]
-
-
-@app.get(
-    "/prediction_model/{prediction_model_name}/grid/{grid_uuid}/latent_representation",
-    response_model=list[QualityPredictionModelParameterResponse],
-)
-async def get_grid_latent_representation(prediction_model_name: str, grid_uuid: str, db: AsyncSession = DB_DEPENDENCY):
-    grid = (await db.execute(select(Grid).where(Grid.uuid == grid_uuid))).scalars().first()
-    if not grid:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Grid {grid_uuid} not found")
-    model = (
-        (await db.execute(select(QualityPredictionModel).where(QualityPredictionModel.name == prediction_model_name)))
-        .scalars()
-        .first()
-    )
-    if not model:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Prediction model {prediction_model_name} not found",
-        )
-    parameters = (
-        (
-            await db.execute(
-                select(QualityPredictionModelParameter).where(
-                    and_(
-                        QualityPredictionModelParameter.grid_uuid == grid_uuid,
-                        QualityPredictionModelParameter.prediction_model_name == prediction_model_name,
-                    )
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    return [QualityPredictionModelParameterResponse.model_validate(param) for param in parameters]
 
 
 # ============ Agent Communication Endpoints ============
@@ -2410,6 +2311,9 @@ async def get_model_weights_for_grid(grid_uuid: str, db: AsyncSession = DB_DEPEN
 async def get_gridsquare_quality_prediction_time_series(gridsquare_uuid: str, db: AsyncSession = DB_DEPENDENCY):
     """Get time ordered predictions for all models that provide them for this square"""
 
+    gridsquare = (await db.execute(select(GridSquare).where(GridSquare.uuid == gridsquare_uuid))).scalars().first()
+    if not gridsquare:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"GridSquare {gridsquare_uuid} not found")
     predictions = (
         (
             await db.execute(
@@ -2433,6 +2337,9 @@ async def get_foilhole_quality_prediction_time_series_for_gridsquare(
 ):
     """Get time ordered predictions for all models that provide them for this square"""
 
+    gridsquare = (await db.execute(select(GridSquare).where(GridSquare.uuid == gridsquare_uuid))).scalars().first()
+    if not gridsquare:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"GridSquare {gridsquare_uuid} not found")
     predictions = (
         await db.execute(
             select(QualityPrediction, FoilHole)

--- a/tests/smartem_backend/test_quality_predictions.py
+++ b/tests/smartem_backend/test_quality_predictions.py
@@ -14,12 +14,30 @@ def _qp_payload(**overrides) -> dict:
     return base
 
 
+def _gridsquare_then(rows):
+    from smartem_backend.model.database import GridSquare
+
+    results = iter(
+        [
+            make_execute_result(GridSquare(uuid="gs-1", grid_uuid="grid-1", gridsquare_id="gs-id-1")),
+            make_execute_result(rows),
+        ]
+    )
+    return lambda *a, **kw: next(results)
+
+
 class TestGetGridSquareQualityPredictions:
     def test_404_when_gridsquare_missing(self, client):
         set_db_row(client, None)
         resp = client.get("/gridsquares/missing/quality_predictions")
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"].lower()
+
+    def test_returns_dict_shaped_time_series(self, client):
+        client._db.execute.side_effect = _gridsquare_then([])
+        resp = client.get("/gridsquares/gs-1/quality_predictions")
+        assert resp.status_code == 200
+        assert resp.json() == {}
 
 
 class TestGetGridSquareFoilHoleQualityPredictions:
@@ -28,6 +46,12 @@ class TestGetGridSquareFoilHoleQualityPredictions:
         resp = client.get("/gridsquares/missing/foilhole_quality_predictions")
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"].lower()
+
+    def test_returns_dict_shaped_time_series(self, client):
+        client._db.execute.side_effect = _gridsquare_then([])
+        resp = client.get("/gridsquares/gs-1/foilhole_quality_predictions")
+        assert resp.status_code == 200
+        assert resp.json() == {}
 
 
 class TestCreateQualityPrediction:


### PR DESCRIPTION
## Summary

Four `GET` paths in `api_server.py` were each registered **twice**. FastAPI matches the first registration and the second is unreachable, but the committed OpenAPI spec (`docs/api/openapi.json`) and the generated frontend client are typed against the **second** handler in every pair (last-wins in the spec's path map). So runtime and contract disagreed.

This removes the first-registered shadowing handler in each pair, keeping the handler the spec / FE client already target.

| Path | Removed (shadowing) | Kept (FE-targeted) |
|---|---|---|
| `/gridsquares/{uuid}/quality_predictions` | `get_gridsquare_quality_predictions` (flat list) | `get_gridsquare_quality_prediction_time_series` (dict time-series) |
| `/gridsquares/{uuid}/foilhole_quality_predictions` | `get_gridsquare_foilhole_quality_predictions` (flat list) | `get_foilhole_quality_prediction_time_series_for_gridsquare` (dict-of-dict) |
| `/prediction_model/{model}/grid/{uuid}/prediction` | `get_grid_predictions` (**500**: lazy-loads `grid.gridsquares` in async) | `get_prediction_for_grid` (explicit `GridSquare` query) |
| `/prediction_model/{model}/grid/{uuid}/latent_representation` | `get_grid_latent_representation` | `get_latent_rep` |

## Why this resolves #298 (and the atlas-page 500s)

- **#298**: the dict-shaped quality-prediction **time-series** endpoints are now reachable, matching the shapes the frontend client is typed against (`{[model]: QualityPrediction[]}` and the per-foilhole nested form). Fixes the square Predictions tab crash (smartem-frontend#117).
- **Atlas-page 500s**: the kept `get_prediction_for_grid` queries `GridSquare` explicitly, so the `MissingGreenlet` lazy-load crash (8x HTTP 500 on every atlas/grid page load) is gone.

## Notes

- The **frontend client needs no regeneration** — its committed `openapi.json` already targets the kept handlers; this PR makes the backend runtime match it. `docs/api/openapi.json` regenerated via `tools/publish_openapi.py`.
- Preserved the **404-on-missing-gridsquare** contract that the removed list handlers provided, by adding the existence check to the two kept time-series handlers.
- Added happy-path regression tests asserting the two gridsquare endpoints return the **dict** shape (not a list).

## Verification

- `uv run pytest tests/smartem_backend` -> 226 passed (incl. 2 new).
- `uv run ruff check/format` clean; pre-commit clean.
- AST scan confirms **0** duplicate `(method, path)` registrations remain (was 4).