### PR TITLE
perf: threadpool + on-disk cache for atlas/grid-square images

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -1,9 +1,11 @@
 import asyncio
+import hashlib
 import io
 import itertools
 import json
 import logging
 import os
+import tempfile
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
@@ -13,8 +15,9 @@ import asyncpg
 import mrcfile
 import tifffile
 from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import Response
+from fastapi.responses import FileResponse
 from PIL import Image
 from pydantic import BaseModel
 from sqlalchemy import and_, desc, or_, select, text
@@ -2763,6 +2766,39 @@ async def get_square_latent_rep(prediction_model_name: str, gridsquare_uuid: str
     return [LatentRepresentationResponse(foilhole_uuid=k, x=v.x, y=v.y, index=v.index) for k, v in rep.items() if v]
 
 
+IMAGE_CACHE_DIR = Path(os.getenv("SMARTEM_IMAGE_CACHE_DIR", str(Path(tempfile.gettempdir()) / "smartem_image_cache")))
+
+
+def _render_image_png(source_path: Path, crop: tuple[int, int, int, int] | None) -> bytes:
+    if source_path.suffix == ".mrc":
+        data = mrcfile.read(source_path)
+    else:
+        data = tifffile.imread(source_path)
+    data = data - data.min()
+    data = data * (255 / data.max())
+    data = data.astype("uint8")
+    if crop is not None:
+        x, y, w, h = crop
+        data = data[y - h // 2 : y + h // 2, x - w // 2 : x + w // 2]
+    image = Image.fromarray(data)
+    with io.BytesIO() as buf:
+        image.save(buf, format="PNG")
+        return buf.getvalue()
+
+
+async def _cached_image_response(source_path: Path, crop: tuple[int, int, int, int] | None) -> FileResponse:
+    stat = source_path.stat()
+    cache_key = hashlib.sha256(f"{source_path}:{stat.st_mtime_ns}:{stat.st_size}:{crop}".encode()).hexdigest()
+    cache_path = IMAGE_CACHE_DIR / f"{cache_key}.png"
+    if not cache_path.exists():
+        png_bytes = await run_in_threadpool(_render_image_png, source_path, crop)
+        IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp_path = cache_path.with_name(f"{cache_key}.{os.getpid()}.tmp")
+        tmp_path.write_bytes(png_bytes)
+        os.replace(tmp_path, cache_path)
+    return FileResponse(cache_path, media_type="image/png", headers={"Cache-Control": "private, max-age=3600"})
+
+
 @app.get("/grids/{grid_uuid}/atlas_image", responses={200: {"content": {"image/png": {}}}})
 async def get_grid_atlas_image(
     grid_uuid: str,
@@ -2782,17 +2818,8 @@ async def get_grid_atlas_image(
         atlas_img_path = atlas_img_path_candidates[0]
     else:
         atlas_img_path = Path(grid.atlas_dir)
-    mrc = mrcfile.read(atlas_img_path)
-    mrc = mrc - mrc.min()
-    mrc = mrc * (255 / mrc.max())
-    mrc = mrc.astype("uint8")
-    if None not in (x, y, w, h):
-        mrc = mrc[y - h // 2 : y + h // 2, x - w // 2 : x + w // 2]
-    im = Image.fromarray(mrc)
-    with io.BytesIO() as buf:
-        im.save(buf, format="PNG")
-        im_bytes = buf.getvalue()
-    return Response(im_bytes, media_type="image/png")
+    crop = (x, y, w, h) if x is not None and y is not None and w is not None and h is not None else None
+    return await _cached_image_response(atlas_img_path, crop)
 
 
 @app.get("/gridsquares/{gridsquare_uuid}/gridsquare_image", responses={200: {"content": {"image/png": {}}}})
@@ -2807,19 +2834,7 @@ async def get_gridsquare_image(
         raise HTTPException(status_code=404, detail="Grid square not found")
     if not gridsquare.image_path:
         raise HTTPException(status_code=404, detail="Grid square image unknown")
-    square_img_path = Path(gridsquare.image_path)
-    if square_img_path.suffix == ".mrc":
-        imdata = mrcfile.read(square_img_path)
-    else:
-        imdata = tifffile.imread(square_img_path)
-    imdata = imdata - imdata.min()
-    imdata = imdata * (255 / imdata.max())
-    imdata = imdata.astype("uint8")
-    im = Image.fromarray(imdata)
-    with io.BytesIO() as buf:
-        im.save(buf, format="PNG")
-        im_bytes = buf.getvalue()
-    return Response(im_bytes, media_type="image/png")
+    return await _cached_image_response(Path(gridsquare.image_path), None)
 
 
 _frontend_sse_connections = 0

--- a/tests/smartem_backend/test_gridsquares.py
+++ b/tests/smartem_backend/test_gridsquares.py
@@ -178,3 +178,30 @@ class TestGetGridSquareImage:
         resp = client.get("/gridsquares/gs-1/gridsquare_image")
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Grid square image unknown"
+
+    def test_renders_png_and_caches(self, client, tmp_path, monkeypatch):
+        import numpy as np
+        import tifffile
+
+        from smartem_backend import api_server
+        from smartem_backend.model.database import GridSquare
+
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(api_server, "IMAGE_CACHE_DIR", cache_dir)
+        source = tmp_path / "square.tiff"
+        tifffile.imwrite(source, np.arange(16, dtype=np.uint16).reshape(4, 4))
+
+        set_db_row(
+            client,
+            GridSquare(uuid="gs-1", grid_uuid="grid-1", gridsquare_id="gs-id-1", image_path=str(source)),
+        )
+        resp = client.get("/gridsquares/gs-1/gridsquare_image")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/png"
+        assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+        cached = list(cache_dir.glob("*.png"))
+        assert len(cached) == 1
+
+        resp2 = client.get("/gridsquares/gs-1/gridsquare_image")
+        assert resp2.status_code == 200
+        assert list(cache_dir.glob("*.png")) == cached


### PR DESCRIPTION
## Summary

The atlas and grid-square image endpoints (`/grids/{uuid}/atlas_image`, `/gridsquares/{uuid}/gridsquare_image`) read an MRC/TIFF, normalise it and PNG-encode it **on every request, synchronously inside the `async` handler**. A 31 MB atlas MRC takes ~15 s to encode, which **blocks the single worker's event loop** — every concurrent request stalls behind it. On an atlas page load a trivial `prediction_models` query was observed finishing at the same instant (15.8 s) as the atlas image, confirming head-of-line blocking.

## Changes

- **Threadpool**: read/normalise/encode moved into a sync helper (`_render_image_png`) invoked via `run_in_threadpool`, so it no longer blocks the event loop.
- **Disk cache** (`_cached_image_response`): the encoded PNG is cached on disk, keyed by `source path + mtime_ns + size + crop box` (atlas `x,y,w,h` included). Cache hits serve the file via `FileResponse` (conditional-request + range support for free). Writes are atomic (`os.replace`). Cache dir is `SMARTEM_IMAGE_CACHE_DIR` (default: a `smartem_image_cache` subdir of the system temp dir).
- **Browser caching**: responses now send `Cache-Control: private, max-age=3600` so repeat navigations don't re-fetch (the handlers previously sent no cache headers).

## Notes

- Behaviour and all existing 404 paths are unchanged.
- This complements the earlier dev memory-limit bump: that stopped the OOM *crash*; this removes the event-loop blocking that made image pages slow even when up.
- **Deploy**: for a persistent cache, mount a volume at `SMARTEM_IMAGE_CACHE_DIR`; otherwise it lives in the pod's ephemeral temp and warms per pod. The cache is immutable-keyed, so no invalidation logic is needed.
- Possible follow-up (out of scope): pre-render at ingest, or move to a tiled image service for atlas zoom/pan (smartem-frontend#111).

## Verification

- New end-to-end test `test_renders_png_and_caches`: real TIFF -> 200 `image/png` (PNG magic asserted) -> cache file created -> second request serves the same cached file.
- `uv run pytest tests/smartem_backend` -> 225 passed.
- `uv run ruff check/format` clean; pre-commit clean. pyright: 165 errors vs 173 on `main` (net -8; pre-existing SQLAlchemy-typing noise, none added).