### PR TITLE
fix: skip foil holes with no cluster index in suggested_holes

### DIFF
--- a/src/smartem_backend/api_server.py
+++ b/src/smartem_backend/api_server.py
@@ -2556,9 +2556,10 @@ async def get_suggested_hole_collections(
     suggested = []
     for i in range(len(scores) // 2):
         hole = scores[i]
-        if cluster_counts[cluster_indices[hole.uuid]] < 4:
+        cluster = cluster_indices.get(hole.uuid)
+        if cluster is not None and cluster_counts[cluster] < 4:
             suggested.append(hole)
-            cluster_counts[cluster_indices[hole.uuid]] += 1
+            cluster_counts[cluster] += 1
     return suggested
 
 

--- a/tests/smartem_backend/test_foilholes.py
+++ b/tests/smartem_backend/test_foilholes.py
@@ -1,5 +1,6 @@
 """TestClient coverage for the /foilholes and /gridsquares/{uuid}/foilholes endpoints (issue #258)."""
 
+from ._async_db_stub import make_execute_result
 from .conftest import set_db_row
 
 
@@ -126,3 +127,36 @@ class TestCreateGridSquareFoilHoles:
         resp = client.post("/gridsquares/gs-1/foilholes", json=[{"uuid": "fh-1"}])
         assert resp.status_code == 422
         assert calls == []
+
+
+class TestSuggestedHoleCollections:
+    def test_skips_holes_missing_from_cluster_indices(self, client):
+        from smartem_backend.model.database import (
+            CurrentQualityPrediction,
+            FoilHole,
+            GridSquare,
+            QualityPredictionModelParameter,
+        )
+
+        gridsquare = GridSquare(uuid="gs-1", grid_uuid="grid-1", gridsquare_id="gs-id-1")
+        holes = [FoilHole(uuid=f"fh-{i}") for i in (1, 2, 3, 4)]
+        preds = [
+            CurrentQualityPrediction(grid_uuid="grid-1", prediction_model_name="m", value=v)
+            for v in (0.9, 0.8, 0.7, 0.6)
+        ]
+        score_rows = list(zip(holes, preds, strict=True))
+        params = [
+            QualityPredictionModelParameter(
+                grid_uuid="grid-1", prediction_model_name="lat", key=key, value=val, group="cluster_indices"
+            )
+            for key, val in (("fh-1", 0.0), ("fh-3", 1.0), ("fh-4", 0.0))
+        ]
+
+        gridsquare_result = make_execute_result(gridsquare)
+        gridsquare_result.scalar_one.return_value = gridsquare
+        results = iter([gridsquare_result, make_execute_result(score_rows), make_execute_result(params)])
+        client._db.execute.side_effect = lambda *a, **kw: next(results)
+
+        resp = client.get("/gridsquares/gs-1/prediction_model/m/latent_rep/lat/suggested_holes")
+        assert resp.status_code == 200
+        assert [hole["uuid"] for hole in resp.json()] == ["fh-1"]


### PR DESCRIPTION
## Summary

Follow-up to #296. `get_suggested_hole_collections` indexed `cluster_indices[hole.uuid]` directly, which raises `KeyError` -> HTTP 500 for any hole in the top-ranked window that has no `cluster_indices` parameter row. (This was the one item from the #296 review that wasn't picked up; the `.scalar_one()` and extract-then-sort fixes were.)

## Change

- Use `cluster_indices.get(hole.uuid)` and skip holes with no cluster index (rather than crash).
- Add a regression test (`TestSuggestedHoleCollections`) where a top-ranked hole is absent from `cluster_indices`; it returns the well-formed suggestions and **500s without the guard**.

## Verification

- `uv run pytest tests/smartem_backend` -> 228 passed (1 new). Confirmed the test fails (500) against the pre-fix handler.
- ruff + pre-commit clean.