### PR TITLE
ci: clear Node 20 action deprecations

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yml
+++ b/.github/workflows/leaked-secrets-scan.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload SARIF to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: gitleaks-report.sarif
           category: gitleaks

--- a/.github/workflows/release-smartem-decisions.yml
+++ b/.github/workflows/release-smartem-decisions.yml
@@ -444,7 +444,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: smartem-decisions-v${{ needs.version.outputs.version }}
           name: SmartEM Decisions v${{ needs.version.outputs.version }}


### PR DESCRIPTION
## What

Bump the two actions still running on Node.js 20 in this repo's workflows.

| Action | Workflow | Change | Why |
|--------|----------|--------|-----|
| `github/codeql-action/upload-sarif` | `leaked-secrets-scan.yml` | `@v3` → `@v4` | Node 20 deprecation **and** a separate "CodeQL Action v3 deprecated Dec 2026, move to v4" warning — v4 clears both |
| `softprops/action-gh-release` | `release-smartem-decisions.yml` | `v2.6.1` → `v3.0.0` (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`) | Node 20 deprecation; v3.0.0 is a pure runtime bump (Node 20 → 24), no functional changes. SHA-pin preserved. |

## How I found them

Pulled live warning annotations from recent runs **and** statically resolved each action's `action.yml` `using:` runtime (deterministic, independent of when a workflow last ran). Verified both targets declare `using: node24`.

## Not in scope

`gitleaks/gitleaks-action@v2` also resolves to Node 20 but is intentionally left out — it needs a separate decision (bump to v3 vs. switch to the gitleaks CLI, as smartem-frontend does).

With this merged, no workflow action here emits a Node 20 deprecation warning except the deliberately-deferred gitleaks-action, ahead of the 2026-06-16 default flip and 2026-09-16 runner removal.